### PR TITLE
feat: add simple mode for reduced phoneme vocabulary

### DIFF
--- a/quranic_phonemizer/phonemizer.py
+++ b/quranic_phonemizer/phonemizer.py
@@ -97,7 +97,10 @@ class Phonemizer:
         debug: bool = False,
         iqlab_phoneme: Optional[str] = None,
         ikhfaa_shafawi_phoneme: Optional[str] = None,
+        mode: Literal["full", "simple"] = "full",
     ) -> PhonemizeResult:
+        if mode not in ("full", "simple"):
+            raise ValueError(f"Invalid mode: {mode!r}. Must be 'full' or 'simple'.")
         if ref is None and ref_text is None:
             raise ValueError("Either 'ref' or 'ref_text' must be provided")
         
@@ -148,7 +151,7 @@ class Phonemizer:
                         print(f"Converted to traditional reference: {ref} (score: {match_score:.3f})")
         
         if failed_match:
-            return PhonemizeResult("", "", [], [], stop_signs, stop_refs, match_score)
+            return PhonemizeResult("", "", [], [], stop_signs, stop_refs, match_score, mode)
         
         self._validate_refs(ref)
 
@@ -176,7 +179,7 @@ class Phonemizer:
             if debug:
                 print(word.debug_print())
 
-        return PhonemizeResult(ref, " ".join(w.text for w in words), all_phonemes, words, stop_signs, stop_refs, match_score)
+        return PhonemizeResult(ref, " ".join(w.text for w in words), all_phonemes, words, stop_signs, stop_refs, match_score, mode)
 
     def _validate_refs(self, ref: str) -> None:
         ref = ref.strip()
@@ -226,16 +229,30 @@ class Phonemizer:
 @dataclass(slots=True)
 class PhonemizeResult:
     ref: str
-    _text: str                     
-    _nested: List[List[str]]       
+    _text: str
+    _nested: List[List[str]]
     _words: List[Word]
     stop_signs: List[str]
     stop_refs: List[str]
     match_score: float = None
+    mode: Literal["full", "simple"] = "full"
+
+    def _view(self, phonemes) -> list[str]:
+        """Return phonemes as a plain list of strings, applying simple-mode collapse when enabled.
+
+        Simple mode only affects the raw phoneme output views
+        (phonemes_list / phonemes_str / show_table / save). Structural outputs
+        (tajweed_mappings, get_mapping, letter_phoneme_mappings) use the full
+        phoneme vocabulary so alignment and rule indices remain consistent.
+        """
+        if self.mode == "simple":
+            from .simple_mode import collapse_phonemes
+            return collapse_phonemes(phonemes)
+        return [str(p) for p in phonemes]
 
     def phonemes_list(self, split: Literal["word", "verse", "both"] = "word") -> list:
         if split == "word":
-            return self._nested
+            return [self._view(word_ph) for word_ph in self._nested]
 
         if split == "verse":
             verses: list[list[str]] = []
@@ -250,8 +267,7 @@ class PhonemizeResult:
                     verses.append(current_verse_phonemes)
                     current_verse_phonemes = []
                     current_verse_id = verse_id
-                for ph in word.get_phonemes():
-                    current_verse_phonemes.append(str(ph))
+                current_verse_phonemes.extend(self._view(word.get_phonemes()))
 
             if current_verse_phonemes:
                 verses.append(current_verse_phonemes)
@@ -270,8 +286,7 @@ class PhonemizeResult:
                     verses_words.append(current_words_in_verse)
                     current_words_in_verse = []
                     current_verse_id = verse_id
-                current_word_ph = [str(p) for p in word.get_phonemes()]
-                current_words_in_verse.append(current_word_ph)
+                current_words_in_verse.append(self._view(word.get_phonemes()))
 
             if current_words_in_verse:
                 verses_words.append(current_words_in_verse)
@@ -338,16 +353,16 @@ class PhonemizeResult:
                 _add_sep(chosen)
                 have_prev_ph = False
 
-            for ph in word.get_phonemes():
+            for ph in self._view(word.get_phonemes()):
                 if have_prev_ph:
                     parts.append(phoneme_sep)
-                parts.append(str(ph))
+                parts.append(ph)
                 have_prev_ph = True
 
             prev_verse, prev_word = cur_verse, cur_word
 
         return "".join(parts) or word_sep.join(
-            phoneme_sep.join(word) for word in self._nested
+            phoneme_sep.join(self._view(word)) for word in self._nested
         )
 
     def tajweed_mappings(self) -> TajweedMapping:
@@ -468,7 +483,7 @@ class PhonemizeResult:
             rows = []
             for word in self._words:
                 clean_word_text = re.sub(r"</?rule[^>]*?>", "", word.text)
-                phoneme_str = phoneme_sep.join(str(p) for p in word.get_phonemes())
+                phoneme_str = phoneme_sep.join(self._view(word.get_phonemes()))
                 rows.append({
                     'location': word.location.location_key,
                     'word': clean_word_text,
@@ -497,7 +512,7 @@ class PhonemizeResult:
                     current_text_parts = []
                     current_list = []
                 current_text_parts.append(re.sub(r"</?rule[^>]*?>", "", word.text))
-                current_list.extend(str(p) for p in word.get_phonemes())
+                current_list.extend(self._view(word.get_phonemes()))
             if current_key is not None:
                 rows.append({
                     'location': current_key,
@@ -513,7 +528,7 @@ class PhonemizeResult:
                 parts = word.location.location_key.split(":")
                 verse_key = ":".join(parts[:2])
                 clean_word_text = re.sub(r"</?rule[^>]*?>", "", word.text)
-                phoneme_str = phoneme_sep.join(str(p) for p in word.get_phonemes())
+                phoneme_str = phoneme_sep.join(self._view(word.get_phonemes()))
                 rows.append({
                     'verse': verse_key,
                     'location': word.location.location_key,
@@ -537,7 +552,7 @@ class PhonemizeResult:
             if split == "word":
                 for word in self._words:
                     ref_key = word.location.location_key
-                    phoneme_map[ref_key] = [str(p) for p in word.get_phonemes()]
+                    phoneme_map[ref_key] = self._view(word.get_phonemes())
                     text_map[ref_key] = _clean_text(word.text)
             elif split == "verse":
                 current_key: str | None = None
@@ -554,7 +569,7 @@ class PhonemizeResult:
                         current_list = []
                         current_text_parts = []
                         current_key = verse_key
-                    current_list.extend(str(p) for p in word.get_phonemes())
+                    current_list.extend(self._view(word.get_phonemes()))
                     current_text_parts.append(_clean_text(word.text))
                 if current_key is not None:
                     phoneme_map[current_key] = current_list
@@ -574,7 +589,7 @@ class PhonemizeResult:
                         current_list = []
                         current_text_parts = []
                         current_key = verse_key
-                    current_list.append([str(p) for p in word.get_phonemes()])
+                    current_list.append(self._view(word.get_phonemes()))
                     current_text_parts.append(_clean_text(word.text))
                 if current_key is not None:
                     phoneme_map[current_key] = current_list
@@ -615,7 +630,7 @@ class PhonemizeResult:
                     for word in self._words:
                         ref_key = word.location.location_key
                         word_text = _clean_text(word.text)
-                        w.writerow([ref_key, word_text, " ".join(str(p) for p in word.get_phonemes())])
+                        w.writerow([ref_key, word_text, " ".join(self._view(word.get_phonemes()))])
                 elif split == "verse":
                     current_key: str | None = None
                     current_text_parts: list[str] = []
@@ -631,7 +646,7 @@ class PhonemizeResult:
                             current_text_parts = []
                             current_list = []
                         current_text_parts.append(_clean_text(word.text))
-                        current_list.extend(str(p) for p in word.get_phonemes())
+                        current_list.extend(self._view(word.get_phonemes()))
                     if current_key is not None:
                         w.writerow([current_key, " ".join(current_text_parts), " ".join(current_list)])
         elif fmt == "mapping":

--- a/quranic_phonemizer/resources/simple_phonemes.yaml
+++ b/quranic_phonemizer/resources/simple_phonemes.yaml
@@ -1,0 +1,36 @@
+# Simple-mode collapse rules.
+#
+# Simple mode produces a reduced phoneme vocabulary by mapping geminated and
+# allophonic variants back to their base phoneme. The collapse is applied as a
+# post-processing pass on the output of the full phonemizer; the underlying
+# per-letter phoneme data is not altered, so tajweed/mapping/alignment views
+# continue to use the full vocabulary.
+#
+# Two-stage algorithm:
+#   1. `replace` — substring replacements applied to each phoneme token
+#      (maps the allophonic variants to their base phoneme).
+#   2. `collapse_geminates` — after replacement, the token is split into
+#      units (base char + attached combining marks: `ˤ`, `~`, `:`) and
+#      consecutive identical units are deduped. This handles geminates,
+#      including geminated emphatics (e.g. `lˤlˤ` -> (stage 1) `ll` ->
+#      (stage 2) `l`; `sˤsˤ` -> (stage 2 only) `sˤ`).
+
+# Tokens dropped from the output entirely.
+drop_tokens:
+  - "Q"      # qalqala release marker
+
+# Substring replacements. Applied in order, to each phoneme token.
+# Only allophonic variants are listed here — the phonemic emphatic
+# consonants (sˤ, dˤ, tˤ, ðˤ from ص ض ط ظ) are preserved as distinct
+# phonemes because they contrast with their plain counterparts.
+replace:
+  "rˤ": "r"     # heavy raa (tafkheem) -> plain r
+  "lˤ": "l"     # heavy lam (Allah) -> plain l
+  "aˤ": "a"     # emphasised fatha -> plain a
+  "ñ": "n"      # idgham-nasalised n (precomposed U+00F1) -> n
+  "m̃": "m"      # idgham-nasalised m (m + U+0303) -> m
+  "j̃": "j"      # idgham-nasalised j (j + U+0303) -> j
+  "w̃": "w"      # idgham-nasalised w (w + U+0303) -> w
+
+# Dedupe consecutive identical units within a token (gemination).
+collapse_geminates: true

--- a/quranic_phonemizer/simple_mode.py
+++ b/quranic_phonemizer/simple_mode.py
@@ -1,0 +1,78 @@
+"""Simple-mode phoneme collapse.
+
+Collapses geminated and allophonic variants of phonemes produced by the full
+phonemizer into a reduced vocabulary. See ``resources/simple_phonemes.yaml``
+for the configured rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+
+
+_CONFIG_PATH = Path(__file__).resolve().parent / "resources" / "simple_phonemes.yaml"
+
+# Marks that attach to a preceding base character when splitting a phoneme
+# token into units for the gemination-collapse pass.
+#   ˤ  (U+02E4)          tafkheem / emphatic
+#   ̃   (U+0303)          combining tilde (idgham nasalisation)
+#   :                    length marker (madd)
+_COMBINING_MARKS = frozenset(["ˤ", "̃", ":"])
+
+_config: Optional[dict] = None
+
+
+def _load_config() -> dict:
+    global _config
+    if _config is None:
+        with _CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            _config = yaml.safe_load(fh) or {}
+    return _config
+
+
+def _split_units(token: str) -> List[str]:
+    """Split a phoneme token into units of (base char + attached marks).
+
+    e.g. ``"sˤsˤ"`` -> ``["sˤ", "sˤ"]``, ``"aˤ:"`` -> ``["aˤ:"]``.
+    """
+    units: List[str] = []
+    for ch in token:
+        if ch in _COMBINING_MARKS and units:
+            units[-1] += ch
+        else:
+            units.append(ch)
+    return units
+
+
+def collapse_token(token: str) -> Optional[str]:
+    """Collapse a single phoneme token. Returns ``None`` if the token is dropped."""
+    cfg = _load_config()
+    if token in (cfg.get("drop_tokens") or []):
+        return None
+
+    out = token
+    for src, dst in (cfg.get("replace") or {}).items():
+        out = out.replace(src, dst)
+
+    if cfg.get("collapse_geminates"):
+        units = _split_units(out)
+        deduped: List[str] = []
+        for u in units:
+            if not deduped or deduped[-1] != u:
+                deduped.append(u)
+        out = "".join(deduped)
+
+    return out
+
+
+def collapse_phonemes(phonemes: Iterable[str]) -> List[str]:
+    """Collapse a sequence of phoneme tokens, dropping any that map to ``None``."""
+    result: List[str] = []
+    for ph in phonemes:
+        collapsed = collapse_token(str(ph))
+        if collapsed is not None:
+            result.append(collapsed)
+    return result


### PR DESCRIPTION
Adds a `mode="simple"` option to Phonemizer.phonemize() that collapses geminated and allophonic variants to their base phoneme, producing a smaller vocabulary suitable for ASR/TTS use cases.

Collapse rules (quranic_phonemizer/resources/simple_phonemes.yaml):
  - drop `Q` (qalqala release marker)
  - map allophonic emphatics to base: rˤ→r, lˤ→l, aˤ→a
  - map idgham nasalised consonants to base: ñ→n, m̃→m, j̃→j, w̃→w
  - collapse adjacent identical units within a token (gemination), which handles geminated allophones (rˤrˤ→r, lˤlˤ→l) as well as geminated phonemic emphatics (sˤsˤ→sˤ; the ˤ on ص/ض/ط/ظ is preserved because it's contrastive, not allophonic)

Simple mode is applied as a post-processing pass in the result output paths (phonemes_list, phonemes_str, show_table, save). Structural views (tajweed_mappings, get_mapping, letter_phoneme_mappings) remain on the full vocabulary so alignment and rule indices stay consistent.