### PR TITLE
feat(phonemizer): silent_flags() per-grapheme silence API + 1-114 audit

### DIFF
--- a/dev/audit_silent_letters.py
+++ b/dev/audit_silent_letters.py
@@ -129,6 +129,7 @@ class Stats:
     pronounced_letters: int = 0
     entries: int = 0
     multi_grapheme_entries: int = 0
+    skipped: int = 0
     # check A — per silent letter
     silent_without_rule: List[dict] = field(default_factory=list)
     silent_rule_dist: Counter = field(default_factory=Counter)
@@ -255,12 +256,36 @@ def all_word_refs(pm: Phonemizer) -> List[str]:
     return refs
 
 
+_CANONICAL_REF = __import__("re").compile(r"^\d+:\d+:\d+(?:-\d+:\d+:\d+)?$")
+
+
+def segment_stops_from_detailed(path: str) -> List[Tuple[str, List[str]]]:
+    """Read a reciter ``detailed.json`` and return ``[(ref, [stop_ref]), ...]``.
+
+    Each segment's ``matched_ref`` span is one recited unit: its FIRST word is a
+    real ibtidaa (start) and its LAST word a real waqf (stop). Non-canonical
+    transition tokens (Basmala, Isti'adha, …) are skipped.
+    """
+    with open(path, encoding="utf-8") as f:
+        doc = json.load(f)
+    out: List[Tuple[str, List[str]]] = []
+    for entry in doc.get("entries", []):
+        for seg in entry.get("segments", []):
+            mref = seg.get("matched_ref", "")
+            if not _CANONICAL_REF.match(mref):
+                continue
+            last = mref.split("-")[-1]  # "s:v:w"
+            out.append((mref, [last]))
+    return out
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--mode", choices=["continuous", "random-stops"],
+    ap.add_argument("--mode", choices=["continuous", "random-stops", "detailed"],
                     default="continuous")
     ap.add_argument("--n-random-stops", type=int, default=50000)
     ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--detailed", help="path to a reciter detailed.json (mode=detailed)")
     ap.add_argument("--out", default="out/audit_silent_letters.json")
     args = ap.parse_args()
 
@@ -281,6 +306,17 @@ def main() -> None:
         for wref in sample:
             s, v, w = wref.split(":")
             audit_one(pm, f"{s}:{v}", [wref], stats)
+
+    elif args.mode == "detailed":
+        if not args.detailed:
+            ap.error("--detailed <path> required for mode=detailed")
+        for ref, stops in segment_stops_from_detailed(args.detailed):
+            try:
+                audit_one(pm, ref, stops, stats)
+            except Exception as e:  # malformed/unsupported span: skip, keep going
+                stats.skipped += 1
+                if stats.skipped <= 10:
+                    print(f"  skip {ref} stop={stops}: {type(e).__name__}: {str(e)[:80]}")
 
     report(stats, args)
 

--- a/dev/audit_silent_letters.py
+++ b/dev/audit_silent_letters.py
@@ -43,6 +43,12 @@ from typing import List, Optional, Set, Tuple
 from quranic_phonemizer import Phonemizer
 from quranic_phonemizer.tajweed_rule import TajweedRule
 from quranic_phonemizer.letter_phoneme_mapping import TANWEEN_DIACRITICS
+from quranic_phonemizer.silent import sounding_in_flat
+
+
+def pronounced_in_flat(word, li: int) -> bool:
+    """Audit shim — the authoritative implementation lives in the package."""
+    return sounding_in_flat(word, li)
 
 
 # Source rules that render a letter silent (zero phonemes) and merged into a
@@ -72,38 +78,6 @@ SILENCE_EXPLAINING_RULES: Set[TajweedRule] = KNOWN_SILENT_SOURCE_RULES | {
     TajweedRule.IDGHAM_SHAFAWI,
 }
 
-# Short vowel phonemes — used to detect the iltiqaa demotion (a long vowel
-# shortened before hamza wasl is stored on the vowel letter as a single short
-# vowel, then the flat builder moves it to the preceding consonant and silences
-# the vowel letter).
-SHORT_VOWELS: Set[str] = {"a", "aˤ", "u", "i"}
-
-
-def pronounced_in_flat(word, li: int) -> bool:
-    """Whether a letter contributes an audible phoneme at its own position in
-    the final flat mapping (i.e. is a highlight target).
-
-    Mirrors the two redistributions the flat builder applies on top of the raw
-    per-letter phonemes:
-      - iltiqaa: a shortened long vowel before hamza wasl moves to the preceding
-        consonant; the vowel letter goes silent.
-      - waqf tanween: when stopping, the long vowel moves from the tanween
-        consonant onto the following (otherwise silent) alef / alef-maksura.
-    """
-    lm = word.letter_mappings[li]
-    src = {t.rule for t in lm.tajweed_rules if t.is_source}
-    if lm.phonemes:
-        if (TajweedRule.SILENT_ILTIQAA_SAKINAYN in src
-                and len(lm.phonemes) == 1 and lm.phonemes[0] in SHORT_VOWELS):
-            return False
-        return True
-    # raw-silent: is it the waqf-tanween redistribution target?
-    if word.is_stopping and lm.char in ("ا", "ى") and li > 0:
-        prev = word.letter_mappings[li - 1]
-        if (prev.diacritic in TANWEEN_DIACRITICS
-                and prev.phonemes and ":" in prev.phonemes[-1]):
-            return True
-    return False
 
 
 @dataclass

--- a/dev/audit_silent_letters.py
+++ b/dev/audit_silent_letters.py
@@ -1,0 +1,360 @@
+"""
+Silent-letter / single-pronounced-grapheme audit for letter-phoneme mappings.
+
+Motivation
+----------
+In the Inspector Timestamps tab we want to highlight, for each phoneme, the
+ONE grapheme that is actually pronounced. The letter-phoneme mapping already
+groups silent letters into the same entry as their sounding neighbour, so each
+flat entry maps one-or-more graphemes to a phoneme run. For highlighting to be
+unambiguous, every entry must contain exactly ONE pronounced grapheme; all
+other graphemes in the entry must be genuinely silent AND carry a tajweed rule
+that explains the silence.
+
+This audit verifies that invariant across an arbitrary set of references, for
+both the continuous (default) and stopping contexts, and characterises every
+violation pattern.
+
+Two checks:
+
+  A. silent-letter completeness — every silent letter (no phonemes) must carry
+     at least one source tajweed rule from KNOWN_SILENT_SOURCE_RULES. A silent
+     letter with no explaining rule is a missing/buggy silent rule.
+
+  B. single-pronounced-grapheme — every flat entry must contain exactly one
+     distinct pronounced letter. Entries with >= 2 pronounced letters cannot be
+     reduced to a single highlight target.
+
+Letters are attributed to flat entries by character-level lockstep: validation
+Rule 2 guarantees that concatenating entry chars (minus spaces) reproduces every
+letter/extension character in order, so we consume a per-character ledger in
+step with the entries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import List, Optional, Set, Tuple
+
+from quranic_phonemizer import Phonemizer
+from quranic_phonemizer.tajweed_rule import TajweedRule
+from quranic_phonemizer.letter_phoneme_mapping import TANWEEN_DIACRITICS
+
+
+# Source rules that render a letter silent (zero phonemes) and merged into a
+# neighbour. The source letter is the one that disappears; its phoneme(s), if
+# any, move to / are subsumed by the target.
+KNOWN_SILENT_SOURCE_RULES: Set[TajweedRule] = {
+    TajweedRule.VOWEL_SILENT,
+    TajweedRule.HAMZA_WASL_SILENT,
+    TajweedRule.LAM_SHAMSIYAH,
+    TajweedRule.IDGHAM_BILA_GHUNNAH_NOON,
+    TajweedRule.IDGHAM_BILA_GHUNNAH_TANWEEN,
+    TajweedRule.IDGHAM_MUTAMATHILAYN,
+    TajweedRule.IDGHAM_MUTAQARIBAYN,
+    TajweedRule.IDGHAM_MUTAJANISAYN_KAMIL,
+    TajweedRule.SILENT_ILTIQAA_SAKINAYN,
+    # idgham with ghunnah: the source NOON letter is silent (assimilated); the
+    # nasalisation is carried on the target letter. The tanween variants do NOT
+    # silence a letter — the letter bearing the tanween is a pronounced consonant.
+    TajweedRule.IDGHAM_GHUNNAH_NOON,
+}
+
+# idgham_shafawi is dual: usually both meems sound (the source meem carries the
+# geminated nasal, the target meem its vowel), but when the target meem's vowel
+# is absorbed by a following long vowel the target meem is silent and explained
+# by idgham_shafawi as a TARGET rule. Counted as a valid silence explanation.
+SILENCE_EXPLAINING_RULES: Set[TajweedRule] = KNOWN_SILENT_SOURCE_RULES | {
+    TajweedRule.IDGHAM_SHAFAWI,
+}
+
+# Short vowel phonemes — used to detect the iltiqaa demotion (a long vowel
+# shortened before hamza wasl is stored on the vowel letter as a single short
+# vowel, then the flat builder moves it to the preceding consonant and silences
+# the vowel letter).
+SHORT_VOWELS: Set[str] = {"a", "aˤ", "u", "i"}
+
+
+def pronounced_in_flat(word, li: int) -> bool:
+    """Whether a letter contributes an audible phoneme at its own position in
+    the final flat mapping (i.e. is a highlight target).
+
+    Mirrors the two redistributions the flat builder applies on top of the raw
+    per-letter phonemes:
+      - iltiqaa: a shortened long vowel before hamza wasl moves to the preceding
+        consonant; the vowel letter goes silent.
+      - waqf tanween: when stopping, the long vowel moves from the tanween
+        consonant onto the following (otherwise silent) alef / alef-maksura.
+    """
+    lm = word.letter_mappings[li]
+    src = {t.rule for t in lm.tajweed_rules if t.is_source}
+    if lm.phonemes:
+        if (TajweedRule.SILENT_ILTIQAA_SAKINAYN in src
+                and len(lm.phonemes) == 1 and lm.phonemes[0] in SHORT_VOWELS):
+            return False
+        return True
+    # raw-silent: is it the waqf-tanween redistribution target?
+    if word.is_stopping and lm.char in ("ا", "ى") and li > 0:
+        prev = word.letter_mappings[li - 1]
+        if (prev.diacritic in TANWEEN_DIACRITICS
+                and prev.phonemes and ":" in prev.phonemes[-1]):
+            return True
+    return False
+
+
+@dataclass
+class CharRec:
+    """One Arabic character (base letter or one extension) in reading order."""
+    ch: str
+    letter_gid: Tuple[int, int]      # (word_idx, letter_idx)
+    base_char: str                   # the owning letter's base char
+    pronounced: bool                 # owning letter has >= 1 phoneme
+    source_rules: Tuple[str, ...]
+    is_stopping: bool
+    location: str
+    diacritic: Optional[str]
+    is_base: bool                    # True for the base char, False for extensions
+
+
+@dataclass
+class Stats:
+    refs: int = 0
+    words: int = 0
+    letters: int = 0
+    silent_letters: int = 0
+    pronounced_letters: int = 0
+    entries: int = 0
+    multi_grapheme_entries: int = 0
+    # check A — per silent letter
+    silent_without_rule: List[dict] = field(default_factory=list)
+    silent_rule_dist: Counter = field(default_factory=Counter)
+    silent_explained_dist: Counter = field(default_factory=Counter)
+    # check B — per flat entry
+    multi_sounding_entries: List[dict] = field(default_factory=list)
+    zero_sounding_entries: List[dict] = field(default_factory=list)
+
+
+def build_char_ledger(mapping) -> List[CharRec]:
+    ledger: List[CharRec] = []
+    for wi, word in enumerate(mapping.words):
+        for li, lm in enumerate(word.letter_mappings):
+            gid = (wi, li)
+            srcset = {t.rule for t in lm.tajweed_rules if t.is_source}
+            pronounced = pronounced_in_flat(word, li)
+            src = tuple(sorted(r.value for r in srcset))
+            ledger.append(CharRec(
+                ch=lm.char, letter_gid=gid, base_char=lm.char, pronounced=pronounced,
+                source_rules=src, is_stopping=word.is_stopping,
+                location=word.location, diacritic=lm.diacritic, is_base=True,
+            ))
+            for ext in lm.extensions:
+                if not ext.char:
+                    continue
+                ledger.append(CharRec(
+                    ch=ext.char, letter_gid=gid, base_char=lm.char, pronounced=pronounced,
+                    source_rules=src, is_stopping=word.is_stopping,
+                    location=word.location, diacritic=lm.diacritic, is_base=False,
+                ))
+    return ledger
+
+
+def attribute_entries(flat, ledger: List[CharRec]) -> List[Tuple[Tuple[str, List[str]], List[CharRec]]]:
+    """Walk flat entries and the char ledger in lockstep; return per-entry chars."""
+    out = []
+    pos = 0
+    for chars, phonemes in flat:
+        want = chars.replace(" ", "")
+        consumed: List[CharRec] = []
+        acc = ""
+        while pos < len(ledger) and len(acc) < len(want):
+            acc += ledger[pos].ch
+            consumed.append(ledger[pos])
+            pos += 1
+        if acc != want:
+            raise RuntimeError(f"lockstep desync: entry {chars!r} want {want!r} got {acc!r}")
+        out.append(((chars, phonemes), consumed))
+    return out
+
+
+def audit_one(pm: Phonemizer, ref: str, stop_refs: List[str], stats: Stats) -> None:
+    res = pm.phonemize(ref, stop_refs=stop_refs) if stop_refs else pm.phonemize(ref)
+    mapping = res.get_mapping()
+    flat = res.letter_phoneme_mappings().to_list()
+    ledger = build_char_ledger(mapping)
+
+    stats.refs += 1
+    stats.words += len(mapping.words)
+    stats.entries += len(flat)
+
+    # ---- Check A: silent-letter completeness (per letter) ----
+    for wi, word in enumerate(mapping.words):
+        for li, lm in enumerate(word.letter_mappings):
+            stats.letters += 1
+            src = {t.rule for t in lm.tajweed_rules if t.is_source}
+            if pronounced_in_flat(word, li):
+                stats.pronounced_letters += 1
+                continue
+            stats.silent_letters += 1
+            allrules = {t.rule for t in lm.tajweed_rules}
+            known = allrules & SILENCE_EXPLAINING_RULES
+            stats.silent_explained_dist[
+                tuple(sorted(r.value for r in known)) or ("<none>",)
+            ] += 1
+            stats.silent_rule_dist[
+                tuple(sorted(r.value for r in allrules)) or ("<no-rules>",)
+            ] += 1
+            if not known:
+                prev_ch = word.letter_mappings[li - 1].char if li > 0 else ""
+                next_ch = word.letter_mappings[li + 1].char if li + 1 < len(word.letter_mappings) else "|"
+                stats.silent_without_rule.append({
+                    "location": word.location,
+                    "char": lm.char,
+                    "ext": [e.char for e in lm.extensions if e.char],
+                    "diacritic": lm.diacritic,
+                    "prev": prev_ch,
+                    "next": next_ch,
+                    "source_rules": sorted(r.value for r in src),
+                    "is_stopping": word.is_stopping,
+                    "word_text": word.text,
+                })
+
+    # ---- Check B: exactly one sounding grapheme per entry ----
+    # The sounding graphemes are those audible in the final flat output
+    # (pronounced_in_flat). Genuine highlight ambiguity = >= 2 distinct sounding
+    # letters in one entry.
+    for (chars, phonemes), consumed in attribute_entries(flat, ledger):
+        if len(consumed) > 1:
+            stats.multi_grapheme_entries += 1
+        sounding = [c for c in consumed if c.pronounced]
+        sounding_gids = {c.letter_gid for c in sounding}
+        if len(sounding_gids) >= 2:
+            stats.multi_sounding_entries.append({
+                "ref": ref, "chars": chars, "phonemes": phonemes,
+                "is_stopping": consumed[0].is_stopping if consumed else None,
+                "sounding_chars": sorted({c.base_char for c in sounding}),
+                "source_rules": sorted({r for c in consumed for r in c.source_rules}),
+            })
+        elif len(sounding_gids) == 0 and phonemes:
+            stats.zero_sounding_entries.append({
+                "ref": ref, "chars": chars, "phonemes": phonemes,
+                "is_stopping": consumed[0].is_stopping if consumed else None,
+                "source_rules": sorted({r for c in consumed for r in c.source_rules}),
+            })
+
+
+def all_word_refs(pm: Phonemizer) -> List[str]:
+    refs = []
+    for s_key, verses in pm._surah_info.items():
+        for vi, wcount in enumerate(verses, start=1):
+            for w in range(1, wcount + 1):
+                refs.append(f"{s_key}:{vi}:{w}")
+    return refs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["continuous", "random-stops"],
+                    default="continuous")
+    ap.add_argument("--n-random-stops", type=int, default=50000)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out", default="out/audit_silent_letters.json")
+    args = ap.parse_args()
+
+    pm = Phonemizer()
+    stats = Stats()
+
+    if args.mode == "continuous":
+        # Phonemize the whole mushaf surah-by-surah, continuous (no stops).
+        for s_key in sorted(pm._surah_info, key=int):
+            audit_one(pm, s_key, [], stats)
+
+    elif args.mode == "random-stops":
+        refs = all_word_refs(pm)
+        rng = random.Random(args.seed)
+        sample = rng.sample(refs, min(args.n_random_stops, len(refs)))
+        # Phonemize each sampled word's verse, stopping on that word, so the
+        # word is rendered in waqf context exactly as a reciter pausing there.
+        for wref in sample:
+            s, v, w = wref.split(":")
+            audit_one(pm, f"{s}:{v}", [wref], stats)
+
+    report(stats, args)
+
+
+def report(stats: Stats, args) -> None:
+    import os
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    print(f"\n=== Silent-letter audit ({args.mode}) ===")
+    print(f"refs phonemized : {stats.refs}")
+    print(f"words           : {stats.words}")
+    print(f"letters         : {stats.letters}")
+    print(f"  pronounced    : {stats.pronounced_letters}")
+    print(f"  silent        : {stats.silent_letters}")
+    print(f"flat entries    : {stats.entries}")
+    print(f"  multi-grapheme: {stats.multi_grapheme_entries}")
+    print()
+    print(f"CHECK A  silent letters with NO known silent rule : {len(stats.silent_without_rule)}")
+    print(f"CHECK B  entries with >=2 sounding graphemes       : {len(stats.multi_sounding_entries)}")
+    print(f"CHECK B  entries with 0 sounding graphemes (anom.) : {len(stats.zero_sounding_entries)}")
+    print()
+
+    print("--- silent letters explained by (known silent rules) ---")
+    for k, c in stats.silent_explained_dist.most_common():
+        print(f"  {c:8d}  {', '.join(k)}")
+
+    if stats.silent_without_rule:
+        print("\n--- CHECK A violations: silent letters lacking a known silent rule ---")
+        by_pat = Counter(
+            (v["char"], tuple(v["source_rules"]), v["is_stopping"])
+            for v in stats.silent_without_rule
+        )
+        for (ch, rules, stop), c in by_pat.most_common():
+            print(f"  {c:8d}  char={ch!r} stop={stop} source_rules={list(rules)}")
+
+    if stats.multi_sounding_entries:
+        print("\n--- CHECK B: entries with >=2 sounding graphemes (pattern counts) ---")
+        by_pat = Counter(
+            (tuple(v["sounding_chars"]), v["is_stopping"], tuple(v["source_rules"]))
+            for v in stats.multi_sounding_entries
+        )
+        for (chs, stop, rules), c in by_pat.most_common(30):
+            print(f"  {c:8d}  sounding={list(chs)} stop={stop} rules={list(rules)}")
+
+    if stats.zero_sounding_entries:
+        print("\n--- CHECK B: entries with 0 sounding graphemes (anomalies) ---")
+        by_pat = Counter(
+            (v["chars"], tuple(v["phonemes"]), v["is_stopping"], tuple(v["source_rules"]))
+            for v in stats.zero_sounding_entries
+        )
+        for (chs, ph, stop, rules), c in by_pat.most_common(30):
+            print(f"  {c:8d}  chars={chs!r} ph={list(ph)} stop={stop} rules={list(rules)}")
+
+    payload = {
+        "mode": args.mode,
+        "summary": {
+            "refs": stats.refs, "words": stats.words, "letters": stats.letters,
+            "pronounced_letters": stats.pronounced_letters,
+            "silent_letters": stats.silent_letters,
+            "entries": stats.entries, "multi_grapheme_entries": stats.multi_grapheme_entries,
+            "check_A_silent_without_rule": len(stats.silent_without_rule),
+            "check_B_multi_sounding": len(stats.multi_sounding_entries),
+            "check_B_zero_sounding": len(stats.zero_sounding_entries),
+        },
+        "silent_explained_dist": {", ".join(k): c for k, c in stats.silent_explained_dist.most_common()},
+        "silent_rule_dist": {", ".join(k): c for k, c in stats.silent_rule_dist.most_common()},
+        "check_A_examples": stats.silent_without_rule[:1000],
+        "check_B_multi_sounding_examples": stats.multi_sounding_entries[:1000],
+        "check_B_zero_sounding_examples": stats.zero_sounding_entries[:1000],
+    }
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/catalog_cells.py
+++ b/dev/catalog_cells.py
@@ -1,0 +1,142 @@
+"""
+Catalogue every multi-grapheme letter-phoneme cell across 1-114.
+
+A "cell" is one ``letter_phoneme_mappings()`` entry; a multi-grapheme cell is the
+phonemizer's grouping that the bucket TS shard reproduces as letters sharing one
+[start,end] span. For each such cell this enumerates, grouped and counted across
+the whole mushaf in BOTH continuous and verse-end-stop context:
+
+  - role pattern  — per grapheme: S silent letter · P pronounced (sounding) ·
+                    X extension (dagger alef / mini waw-yaa)
+  - rules         — the tajweed rule(s) that make the silent graphemes silent
+                    (UNRULED = the otiose tanween alef, which carries none)
+  - cross-word    — whether the cell spans a word boundary
+  - false-tagged  — the P grapheme(s): what a naive "duplicate-span ⇒ silent"
+                    rule would wrongly skip
+  - example       — the word(s) the cell sits in
+
+The point is to let a human decide, per pattern, what is a real false-tag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections import Counter, defaultdict
+
+from quranic_phonemizer import Phonemizer
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+from audit_silent_letters import (  # noqa: E402
+    build_char_ledger, attribute_entries, pronounced_in_flat,
+    SILENCE_EXPLAINING_RULES,
+)
+
+_RULE_TAG = re.compile(r"</?rule[^>]*?>")
+_KNOWN = {r.value for r in SILENCE_EXPLAINING_RULES}
+
+
+def _clean(t: str) -> str:
+    return _RULE_TAG.sub("", t)
+
+
+def catalogue(pm: Phonemizer, refs, ctx_label, agg, examples):
+    for ref, stops in refs:
+        res = pm.phonemize(ref, stop_refs=stops) if stops else pm.phonemize(ref)
+        m = res.get_mapping()
+        flat = res.letter_phoneme_mappings().to_list()
+        ledger = build_char_ledger(m)
+        loc2text = {w.location: _clean(w.text) for w in m.words}
+        gid2letter = {
+            (wi, li): lm
+            for wi, w in enumerate(m.words)
+            for li, lm in enumerate(w.letter_mappings)
+        }
+        for (chars, phon), consumed in attribute_entries(flat, ledger):
+            if len(consumed) <= 1:
+                continue
+            roles, rules, words = [], set(), []
+            for c in consumed:
+                if c.location not in words:
+                    words.append(c.location)
+                lm = gid2letter[c.letter_gid]
+                allr = {t.rule.value for t in lm.tajweed_rules}
+                if not c.is_base:
+                    roles.append("X")
+                elif c.pronounced:
+                    roles.append("P")
+                else:
+                    roles.append("S")
+                    known = allr & _KNOWN
+                    rules |= known if known else {"UNRULED"}
+            cross = " " in chars.strip()
+            key = (" ".join(roles), tuple(sorted(rules)), cross, ctx_label)
+            agg[key] += 1
+            if len(examples[key]) < 4:
+                wt = " ‖ ".join(loc2text.get(w, w) for w in words)
+                examples[key].add((chars, tuple(phon), wt))
+
+
+def all_surahs():
+    return [(str(s), []) for s in range(1, 115)]
+
+
+def all_verse_stops(pm):
+    out = []
+    for s_key, verses in pm._surah_info.items():
+        for vi in range(1, len(verses) + 1):
+            out.append((f"{s_key}:{vi}", [f"{s_key}:{vi}:{verses[vi-1]}"]))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="out/cell_catalogue.md")
+    args = ap.parse_args()
+    pm = Phonemizer()
+    agg = Counter()
+    examples = defaultdict(set)
+
+    catalogue(pm, all_surahs(), "cont", agg, examples)
+    catalogue(pm, all_verse_stops(pm), "stop", agg, examples)
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    # Merge cont/stop into one row per (roles, rules, cross).
+    merged = defaultdict(lambda: {"cont": 0, "stop": 0})
+    ex_by_struct = {}
+    for (roles, rules, cross, ctx), cnt in agg.items():
+        struct = (roles, rules, cross)
+        merged[struct][ctx] += cnt
+        ex_by_struct.setdefault(struct, sorted(examples[(roles, rules, cross, ctx)])[0]
+                                if examples[(roles, rules, cross, ctx)] else None)
+
+    rows = sorted(merged.items(), key=lambda kv: -(kv[1]["cont"] + kv[1]["stop"]))
+
+    lines = ["# Multi-grapheme cell catalogue (letter-phoneme = shard duplicate-span)\n"]
+    lines.append("Every grouped cell across 1-114. Roles per grapheme: **S** silent "
+                 "letter · **P** pronounced (sounding) · **X** extension. "
+                 "`P (false-tag)` = how many sounding graphemes a naive "
+                 "\"duplicate-span ⇒ silent\" rule would wrongly skip in this cell.\n")
+    lines.append("| # | roles | silencing rules | cross-word | cont | stop | "
+                 "P (false-tag) | example cell → phones | word(s) |")
+    lines.append("|---|---|---|---|--:|--:|--:|---|---|")
+    for i, ((roles, rules, cross), c) in enumerate(rows, 1):
+        nP = roles.split().count("P")
+        ex = ex_by_struct[(roles, rules, cross)]
+        chars, phon, wt = ex if ex else ("", (), "")
+        lines.append(
+            f"| {i} | `{roles}` | {', '.join(rules)} | {'yes' if cross else ''} | "
+            f"{c['cont']} | {c['stop']} | {nP} | `{chars}` → {list(phon)} | {wt} |"
+        )
+    with open(args.out, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print("\n".join(lines))
+    print(f"\n[{len(rows)} distinct patterns; wrote {args.out}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/reconcile_tokenization.py
+++ b/dev/reconcile_tokenization.py
@@ -114,14 +114,86 @@ def part2_shard_vs_lp(pm: Phonemizer, shard_path: str) -> None:
         print("  MISMATCH", mm)
 
 
+def part3_shard_silence_heuristic(pm: Phonemizer, shard_path: str) -> None:
+    """Can the silent grapheme be inferred from the shard's timing alone?
+
+    Tests the "duplicate-span" signal (a silent letter is given the SAME
+    [start,end] as its sounding neighbour): for each grapheme, compare
+    "shares an exact span with a neighbour" against the phonemizer ground truth
+    (silent vs sounding vs extension), and locate where the sounding grapheme
+    sits inside each duplicate-span group.
+    """
+    import sys
+    sys.path.insert(0, __import__("os").path.dirname(__file__))
+    from audit_silent_letters import pronounced_in_flat
+
+    doc = json.load(open(shard_path, encoding="utf-8"))
+    ch = doc["_meta"]["chapter"]
+    miss = false_tag = 0
+    pos = Counter()
+    for seg in doc["segments"]:
+        ref = seg["ref"]
+        if not _CANON_VERSE.match(ref):
+            continue
+        widxs = [w[0] for w in seg["words"]]
+        if widxs != list(range(widxs[0], widxs[0] + len(widxs))):
+            continue
+        s, v = ref.split(":")
+        lo, hi = widxs[0], widxs[-1]
+        span = f"{s}:{v}:{lo}" if lo == hi else f"{s}:{v}:{lo}-{s}:{v}:{hi}"
+        try:
+            mapping = pm.phonemize(span, stop_refs=[f"{s}:{v}:{hi}"]).get_mapping()
+        except Exception:
+            continue
+        gt = []
+        for w in mapping.words:
+            for li, lm in enumerate(w.letter_mappings):
+                gt.append("sound" if pronounced_in_flat(w, li) else "silent")
+                gt += ["ext" for e in lm.extensions if e.char]
+        sh = [(L[1], L[2]) for w in seg["words"] for L in w[3]]
+        if len(sh) != len(gt):
+            continue
+        n = len(sh)
+        for i in range(n):
+            dup = (i > 0 and sh[i - 1] == sh[i]) or (i < n - 1 and sh[i + 1] == sh[i])
+            if gt[i] == "silent" and not dup:
+                miss += 1
+            if gt[i] == "sound" and dup:
+                false_tag += 1
+        i = 0
+        while i < n:
+            j = i
+            while j + 1 < n and sh[j + 1] == sh[i]:
+                j += 1
+            if j > i:
+                snd = [k - i for k in range(i, j + 1) if gt[k] == "sound"]
+                if snd == [0]:
+                    pos["sounding FIRST"] += 1
+                elif snd == [j - i]:
+                    pos["sounding LAST"] += 1
+                elif not snd:
+                    pos["no sounding"] += 1
+                else:
+                    pos["mid/multi"] += 1
+            i = j + 1
+
+    print(f"\n=== Part 3: can silence be inferred from shard timing alone? (surah {ch}) ===")
+    print(f"silent graphemes the duplicate-span signal MISSES   : {miss}")
+    print(f"sounding graphemes it would WRONGLY skip            : {false_tag}")
+    print("position of the sounding grapheme in duplicate-span groups:")
+    for k, c in pos.most_common():
+        print(f"  {c:4d}  {k}")
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--shard", help="path to a TS shard JSON (decompressed) for Part 2")
+    ap.add_argument("--shard", help="path to a TS shard JSON (decompressed) for Parts 2+3")
     args = ap.parse_args()
     pm = Phonemizer()
     part1_tajweed_vs_lp(pm)
     if args.shard:
         part2_shard_vs_lp(pm, args.shard)
+        part3_shard_silence_heuristic(pm, args.shard)
 
 
 if __name__ == "__main__":

--- a/dev/reconcile_tokenization.py
+++ b/dev/reconcile_tokenization.py
@@ -1,0 +1,128 @@
+"""
+Tokenization reconciliation: tajweed vs letter-phoneme vs the bucket TS shard.
+
+Three grapheme tokenizations are in play for the Timestamps tab highlight:
+
+  1. ``tajweed_mappings()``   — one entry per grapheme, real extensions split,
+     BUT it injects a synthetic dagger-alef for lafdh jalalah (Allah's implicit
+     madd) and spells muqattaat out as letter NAMES (أَلِف لَام …).
+  2. ``letter_phoneme_mappings()`` — same per-grapheme atoms over the ACTUAL
+     written text (no synthetic Allah dagger, muqattaat kept as written), then
+     silent graphemes are GROUPED into their sounding neighbour's entry.
+  3. The bucket TS shard ``letters[]`` (``reciters/<slug>/timestamps/<ch>.json.gz``)
+     — one ``[char, start_ms, end_ms]`` per grapheme of the actual written text,
+     real extensions split, silent letters NOT grouped but given the SAME
+     timespan as their sounding neighbour (the FE "one cell" behaviour).
+
+Part 1 quantifies where (1) and (2) diverge across 1-114 (atoms only).
+Part 2 proves the shard ``letters[]`` equals the letter-phoneme ATOMS on a real
+shard fixture (per word, char-for-char), so the letter-phoneme silent/sounding
+classification can be stamped onto shard letters 1:1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+
+from quranic_phonemizer import Phonemizer
+
+_CANON_VERSE = re.compile(r"^\d+:\d+$")
+
+
+def _grapheme_chars(letter) -> str:
+    """A letter's written graphemes: base char + each (split) extension char."""
+    return letter.char + "".join(e.char for e in letter.extensions if e.char)
+
+
+def part1_tajweed_vs_lp(pm: Phonemizer) -> None:
+    """Compare tajweed vs letter-phoneme grapheme atoms across 1-114, by word."""
+    total_words = mismatch_words = 0
+    by_cause: Counter = Counter()
+    for s in range(1, 115):
+        res = pm.phonemize(str(s))
+        mapping = res.get_mapping()
+        taj = res.tajweed_mappings()
+        # taj words can be more numerous than mapping words (muqattaat split into
+        # multiple letter-name words), so compare at the SURAH grapheme level for
+        # atoms, but attribute causes per mapping word.
+        taj_seq = "".join(e.char for w in taj.words for e in w.entries)
+        lp_seq = "".join(_grapheme_chars(lm) for w in mapping.words for lm in w.letter_mappings)
+        for w in mapping.words:
+            total_words += 1
+            if w.is_special_word:
+                by_cause["muqattaat (spelled out in tajweed)"] += 1
+                mismatch_words += 1
+            elif any(mm.is_lafdh_jalalah for mm in w.madd_mappings):
+                by_cause["lafdh jalalah (synthetic dagger in tajweed)"] += 1
+                mismatch_words += 1
+            elif any(mm.is_hamza_fathatan for mm in w.madd_mappings):
+                by_cause["hamza+fathatan (exempt madd)"] += 1
+        if taj_seq != lp_seq:
+            by_cause["_surah_atom_mismatch"] += 1
+
+    print("=== Part 1: tajweed vs letter-phoneme atoms (1-114) ===")
+    print(f"words total                 : {total_words}")
+    print(f"words diverging (by cause)  :")
+    for cause, c in by_cause.most_common():
+        if cause.startswith("_"):
+            continue
+        print(f"  {c:6d}  {cause}")
+    print(f"surahs with any atom mismatch: {by_cause['_surah_atom_mismatch']}/114")
+
+
+def part2_shard_vs_lp(pm: Phonemizer, shard_path: str) -> None:
+    """Prove shard letters[] == letter-phoneme atoms per word on a real fixture."""
+    doc = json.load(open(shard_path, encoding="utf-8"))
+    ch = doc["_meta"]["chapter"]
+    seg_ok = seg_total = word_ok = word_total = 0
+    mismatches = []
+    for seg in doc["segments"]:
+        ref = seg["ref"]
+        if not _CANON_VERSE.match(ref):
+            continue
+        widxs = [w[0] for w in seg["words"]]
+        if widxs != list(range(widxs[0], widxs[0] + len(widxs))):
+            continue
+        s, v = ref.split(":")
+        lo, hi = widxs[0], widxs[-1]
+        span = f"{s}:{v}:{lo}" if lo == hi else f"{s}:{v}:{lo}-{s}:{v}:{hi}"
+        try:
+            mapping = pm.phonemize(span, stop_refs=[f"{s}:{v}:{hi}"]).get_mapping()
+        except Exception:
+            continue
+        seg_total += 1
+        ok = True
+        for wi, word in enumerate(mapping.words):
+            ph = "".join(_grapheme_chars(lm) for lm in word.letter_mappings)
+            sh = "".join(L[0] for L in seg["words"][wi][3]) if wi < len(seg["words"]) else ""
+            word_total += 1
+            if ph == sh:
+                word_ok += 1
+            else:
+                ok = False
+                if len(mismatches) < 10:
+                    mismatches.append((span, wi, ph, sh))
+        seg_ok += ok
+
+    print(f"\n=== Part 2: shard vs letter-phoneme atoms (surah {ch}) ===")
+    print(f"segments fully matching: {seg_ok}/{seg_total}")
+    print(f"words matching         : {word_ok}/{word_total}")
+    for mm in mismatches:
+        print("  MISMATCH", mm)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shard", help="path to a TS shard JSON (decompressed) for Part 2")
+    args = ap.parse_args()
+    pm = Phonemizer()
+    part1_tajweed_vs_lp(pm)
+    if args.shard:
+        part2_shard_vs_lp(pm, args.shard)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/cell-catalogue.md
+++ b/docs/cell-catalogue.md
@@ -1,0 +1,34 @@
+# Multi-grapheme cell catalogue (letter-phoneme = shard duplicate-span)
+
+Every grouped cell across 1-114. Roles per grapheme: **S** silent letter · **P** pronounced (sounding) · **X** extension. `P (false-tag)` = how many sounding graphemes a naive "duplicate-span ⇒ silent" rule would wrongly skip in this cell.
+
+| # | roles | silencing rules | cross-word | cont | stop | P (false-tag) | example cell → phones | word(s) |
+|---|---|---|---|--:|--:|--:|---|---|
+| 1 | `S P` | hamza_wasl_silent |  | 6673 | 6513 | 1 | `ٱل` → ['l'] | ٱلْحَمْدُ |
+| 2 | `P X` |  |  | 5535 | 5559 | 1 | `آ` → ['aˤ:'] | ٱلضَّآلِّينَ |
+| 3 | `S S P` | hamza_wasl_silent, lam_shamsiyah |  | 4120 | 4072 | 1 | `ٱلد` → ['dd'] | ٱلدِّينِ |
+| 4 | `P S` | vowel_silent |  | 3000 | 2996 | 1 | `أو` → ['ʔ', 'u'] | أُو۟لَـٰٓئِكَ |
+| 5 | `P S` | UNRULED |  | 3145 | 2249 | 1 | `دى ` → ['d', 'a'] | هُدًى |
+| 6 | `S S P` | hamza_wasl_silent, silent_iltiqaa_sakinayn | yes | 1447 | 1437 | 1 | `ا ٱل` → ['l'] | تَحْتِهَا ‖ ٱلْأَنْهَـٰرُ ۖ |
+| 7 | `S P` | idgham_ghunnah_noon | yes | 1022 | 1022 | 1 | `ن م` → ['m̃', 'i'] | مِّن ‖ مِّثْلِهِۦ |
+| 8 | `X X` |  |  | 953 | 951 | 0 | `ٰٓ` → ['a:'] | أُو۟لَـٰٓئِكَ |
+| 9 | `S S S P` | hamza_wasl_silent, lam_shamsiyah, silent_iltiqaa_sakinayn | yes | 737 | 735 | 1 | `ا ٱلص` → ['sˤsˤ', 'i'] | ٱهْدِنَا ‖ ٱلصِّرَٰطَ |
+| 10 | `P P` |  | yes | 706 | 705 | 2 | `م م` → ['m̃', 'a'] | قُلُوبِهِم ‖ مَّرَضٌ |
+| 11 | `P X S` | vowel_silent |  | 527 | 527 | 1 | `وٓا ` → ['u:'] | تَكُونُوٓا۟ |
+| 12 | `P X X` |  |  | 392 | 394 | 1 | `ىٰٓ ` → ['a:'] | مُوسَىٰٓ |
+| 13 | `S P` | idgham_bila_ghunnah_noon | yes | 338 | 338 | 1 | `ن ر` → ['rˤrˤ', 'aˤ'] | مِن ‖ رَّبِّهِمْ ۖ |
+| 14 | `S S S S P` | hamza_wasl_silent, lam_shamsiyah, silent_iltiqaa_sakinayn, vowel_silent | yes | 293 | 293 | 1 | `وا ٱلز` → ['zz', 'a'] | وَءَاتُوا۟ ‖ ٱلزَّكَوٰةَ |
+| 15 | `S S S P` | hamza_wasl_silent, silent_iltiqaa_sakinayn, vowel_silent | yes | 202 | 202 | 1 | `وا ٱل` → ['l'] | تَلْبِسُوا۟ ‖ ٱلْحَقَّ |
+| 16 | `S P` | lam_shamsiyah |  | 133 | 183 | 1 | `لر` → ['rr', 'i'] | وَلِلرِّجَالِ |
+| 17 | `P S` | idgham_shafawi | yes | 125 | 125 | 1 | `م م` → ['m̃'] | جَآءَكُم ‖ مُّوسَىٰ |
+| 18 | `S P` | idgham_mutamathilayn | yes | 122 | 122 | 1 | `ب ب` → ['bb', 'i'] | ٱضْرِب ‖ بِّعَصَاكَ |
+| 19 | `S P` | idgham_mutajanisayn_kamil |  | 38 | 38 | 1 | `دت` → ['tt', 'a'] | وَعَدتَّنَا |
+| 20 | `P S S` | idgham_mutamathilayn, vowel_silent |  | 22 | 22 | 1 | `توا ` → ['t', 'a'] | أَتَوا۟ |
+| 21 | `S P` | idgham_mutajanisayn_kamil | yes | 20 | 20 | 1 | `ت ط` → ['tˤtˤ'] | هَمَّت ‖ طَّآئِفَتَانِ |
+| 22 | `S P` | idgham_mutaqaribayn | yes | 12 | 12 | 1 | `ل ر` → ['rˤrˤ', 'aˤ'] | بَل ‖ رَّفَعَهُ |
+| 23 | `S P` | idgham_mutamathilayn |  | 4 | 4 | 1 | `كك` → ['kk', 'u'] | يُدْرِككُّمُ |
+| 24 | `P X X S` | vowel_silent |  | 2 | 2 | 1 | `وٰٓا ` → ['a:'] | ٱلرِّبَوٰٓا۟ |
+| 25 | `X X S` | vowel_silent |  | 2 | 2 | 0 | `ۥٓا ` → ['u:'] | تَلْوُۥٓا۟ |
+| 26 | `P P S` | vowel_silent | yes | 2 | 2 | 2 | `م ما` → ['m̃', 'i'] | مِّنكُم ‖ مِّا۟ئَةٌ |
+| 27 | `X S` | vowel_silent |  | 1 | 1 | 0 | `ۥا ` → ['u:'] | لِتَسْتَوُۥا۟ |
+| 28 | `S P` | idgham_mutaqaribayn |  | 1 | 1 | 1 | `قك` → ['kk', 'u'] | نَخْلُقكُّم |

--- a/docs/silent-letter-audit.md
+++ b/docs/silent-letter-audit.md
@@ -1,0 +1,187 @@
+# Silent-Letter / Single-Pronounced-Grapheme Audit
+
+## Why this exists
+
+A phoneme always has a sound, but it is frequently written with **several
+graphemes** of which only **one is actually pronounced** — the rest are silent
+(hamza wasl, lam shamsiyah, the otiose alef, idgham-assimilated noon, …). The
+Inspector Timestamps tab wants to highlight, per phoneme, the **one** grapheme
+that is uttered, rather than lighting up the whole silent cluster.
+
+This audit answers: *across the whole muṣḥaf, in both continuous and stopping
+recitation, is every silent grapheme accounted for, so that each phoneme group
+reduces to exactly one pronounced grapheme?*
+
+Reproduce with `dev/audit_silent_letters.py` (`--mode continuous` /
+`--mode random-stops`).
+
+## How the letter-phoneme mapping already helps
+
+`result.letter_phoneme_mappings()` already groups every silent grapheme into the
+same flat entry as its sounding neighbour, so each entry maps *one-or-more
+graphemes → a phoneme run*. The audit therefore reduces to two checks:
+
+- **Check A — silent-letter completeness.** Every silent letter (no audible
+  phoneme in the flat output) must carry a tajweed rule that explains the
+  silence. A silent letter with no explaining rule is a missing/implicit rule.
+- **Check B — single sounding grapheme.** Every flat entry must contain exactly
+  one *distinct* sounding letter. Entries with ≥ 2 cannot be reduced to a single
+  highlight target.
+
+### "Sounding in the flat output" ≠ raw per-letter phonemes
+
+Two redistributions mean the raw `letter_mappings[].phonemes` is **not** a
+reliable highlight signal — `dev/audit_silent_letters.py::pronounced_in_flat`
+mirrors both:
+
+| Case | Raw mapping | Flat output (what to highlight) |
+|---|---|---|
+| **Iltiqaa** (long vowel shortened before hamza wasl, e.g. `فِى ٱل…`) | the vowel letter keeps the demoted short vowel | vowel letter is **silent**; the short vowel moves back onto the preceding consonant |
+| **Waqf tanween** (stopping on `…ًا`) | the consonant carries the `a:` | the `a:` moves onto the **alef**, which becomes the sounding madd carrier |
+
+Also note `vowel_silent` is **over-tagged** in the raw layer: it is attached to
+pronounced madd carriers like the `ى` of `مُوسَىٰ` (which sounds `a:`).
+`tajweed_mappings()` strips it from madd carriers, but anything reading the raw
+`letter_mappings` must not treat a letter as silent just because it carries
+`vowel_silent` — check the phonemes.
+
+## Results — continuous (all 114 surahs at once)
+
+```
+words 77,433 · letters 326,199 · flat entries 304,667
+silent letters 30,337 · multi-grapheme entries 29,574
+
+CHECK A  silent letters with no explaining rule : 3,145
+CHECK B  entries with ≥2 sounding graphemes      : 708
+CHECK B  entries with 0 sounding graphemes (anom): 3
+```
+
+Silent letters, by explaining rule:
+
+| Rule | Count |
+|---|---|
+| `hamza_wasl_silent` | 13,472 |
+| `lam_shamsiyah` | 5,283 |
+| `vowel_silent` | 4,051 |
+| **(none — see Finding 1)** | **3,145** |
+| `silent_iltiqaa_sakinayn` | 2,682 |
+| `idgham_ghunnah_noon` | 1,022 |
+| `idgham_bila_ghunnah_noon` | 338 |
+| `idgham_mutamathilayn` | 148 |
+| `idgham_shafawi` (target) | 125 |
+| `idgham_mutajanisayn_kamil` | 58 |
+| `idgham_mutaqaribayn` | 13 |
+
+## Findings
+
+### Finding 1 — the tanween alef/maksura is silent but carries no rule (3,145)
+
+The **only** systematic Check A gap. The silent alef (`ـًا`, e.g. `نَارًا`,
+`رِزْقًا`) and silent alef-maksura (`ـًى`, e.g. `هُدًى`) that follow a fathatan
+are silent **when continuing** (the `an` nasal sits on the consonant; the alef
+is the orthographic *alif al-wiqāyah*), yet they receive **no source rule** —
+not even `vowel_silent`.
+
+- Breakdown: 3,052 `ا` + 93 `ى`. (Context: the alef follows every consonant
+  carrying fathatan — `ر ل م د ن ب ق ع …`.)
+- It is **handled in the flat mapping** anyway: the merge falls back to a
+  by-character `PREV` merge that the builder internally labels
+  `vowel_lengthening_failure` (a tell-tale name), so the alef is silently glued
+  to the consonant. The gap only bites a consumer that decides silence from
+  **tajweed rules** instead of the flat grouping.
+- **When stopping**, this same alef flips to the **sounding** madd carrier
+  (madd ʿiwaḍ → `a:`); it is *not* a violation there. So any fix must be
+  context-aware (silent continuing, sounding at waqf), exactly mirroring
+  `pronounced_in_flat`.
+- **Recommendation (needs a decision):** tag the continuing tanween alef/maksura
+  with `vowel_silent` (or a dedicated `tanween_alef_silent`) so the tajweed
+  layer is self-consistent. This adds rules to `tajweed_mappings()` output, so
+  it is a deliberate change, not a silent bugfix.
+
+### Finding 2 — `idgham_shafawi` is the only genuine "two sounding graphemes" case (708)
+
+Every Check B ≥2-sounding entry is مْ + م (`لَهُم مَّرَضٌ` → `'م م'` →
+`['m̃','a']`), where the source meem carries the geminated nasal and the target
+meem its vowel — both audible. This is the single pattern where one phoneme
+group cannot be reduced to one grapheme automatically.
+
+`idgham_shafawi` is **dual**, and the renderer chooses per-context:
+
+- **both sounding** (708) — target meem keeps its own vowel; *or*
+- **target silent** (125, counted under `idgham_shafawi` in Check A) — when the
+  target meem's vowel is absorbed by a following long vowel (`لَكُم مَّا` →
+  source `م`=`['m̃']`, target `م`=`[]`).
+
+**Highlight convention needed:** for the both-sounding case, pick one meem to
+highlight (recommend the **second/target meem** — it bears the shaddah and the
+held ghunnah). This is the one place the highlight rule must be hand-specified.
+
+### Finding 3 — madd silah (`ۥ`/`ۦ`) silent at waqf is handled implicitly
+
+The connecting silah (`ـهُۥ`, `ـهِۦ`) lengthens to `u:`/`i:` when continuing
+into a consonant, and goes **silent when stopping** (`تَأْخُذُهُۥ` stop →
+`'هۥ '` → `['h']`). Because the silah is an **extension** of the haa (not a base
+letter), it merges into the haa entry and never appears as a competing sounding
+grapheme — Check A skips it and Check B sees a single sounding haa. No rule is
+attached, but there is no ambiguity. A highlighter must treat the silah
+extension as silent-when-its-base-has-no-long-vowel.
+
+### Finding 4 — multi-silent / cross-word chains already collapse correctly
+
+Sequences of 2–3 silent graphemes, including across word boundaries
+(`فِى ٱلْأَرْضِ` → `'ى ٱل'` → `['l']`: silent yaa + silent hamza-wasl + sounding
+lam; cross-word noon idgham `'ن ل'`), all reduce to a single sounding grapheme.
+No violations.
+
+### Anomalies (3) — audit heuristic limitation, not a phonemizer bug
+
+Three iltiqaa entries (`'ا '`→`['a']`, `'ى '`→`['i']`) hit the builder's
+`vowel_entry_idx == 0` fallback: the long vowel is **not** demoted (kept as a
+short vowel with a space suffix) because there is no preceding consonant in the
+entry to receive it. `pronounced_in_flat` over-eagerly silences them. Cosmetic;
+listed for completeness.
+
+## Results — stopping (50k random waqf words)
+
+For each of 50,000 randomly-sampled words, its verse is phonemized **stopping on
+that word**, so the word is rendered in real waqf context.
+
+```
+words 978,669 · letters 4,089,311 · flat entries 3,824,053
+silent letters 371,011
+
+CHECK A  silent letters with no explaining rule : 27,697   (all char ا/ى, all continuing)
+CHECK B  entries with ≥2 sounding graphemes      : 8,845    (all idgham_shafawi)
+CHECK B  entries with 0 sounding graphemes (anom): 50       (iltiqaa heuristic edge)
+```
+
+**The decisive result: zero `stop=True` Check A violations.** Across 50k waqf
+points, stopping introduces **no** new unexplained silent letter. Every Check A
+violation is still the tanween alef/maksura **on a continuing word**
+(26,547 `ا` + 1,150 `ى`) — when the stop actually lands on a tanween word the
+alef becomes the sounding madd-ʿiwaḍ carrier, so it is not flagged. The waqf
+machinery (madd ʿiwaḍ, silah-goes-silent, qalqala kubra, final sukun) is fully
+covered by rules or by the flat grouping. Findings 1–4 are therefore identical
+in both contexts; the audit is **complete for continuous and stopping**.
+
+## Implications for the Timestamps highlight feature
+
+1. The flat `letter_phoneme_mappings()` is **already** a near-perfect basis:
+   every entry has exactly one sounding grapheme except the 708 idgham_shafawi
+   entries. Highlight = the sounding grapheme of each entry.
+2. The mapping does **not currently expose** *which* grapheme is the sounding
+   one (it returns only `chars` + `phonemes`). The natural next step is a small
+   API that, per entry, returns the sounding grapheme index — `pronounced_in_flat`
+   already encodes the rule. Open question for the user before building it.
+3. Deciding silence from **tajweed rules** instead of the flat grouping requires
+   Finding 1 (tanween alef) to be fixed first.
+4. `idgham_shafawi` needs an explicit highlight convention (Finding 2).
+
+## Next step — bucket validation
+
+Validate against real reciter stop points: read where each reciter actually
+paused (from their segments in the bucket), phonemize each pause in waqf
+context, and confirm the silent/sounding split holds at *their* stops (start
+with one reciter, then scale). Tokenisation note: letter-phoneme grouping may
+differ slightly from tajweed-rule tokenisation — reconcile the two before
+splitting Timestamps cells per token.

--- a/docs/silent-letter-audit.md
+++ b/docs/silent-letter-audit.md
@@ -206,3 +206,29 @@ bucket TS-shard `letters[]` tokenization equals the **letter-phoneme atoms**
 (proven char-for-char on a real shard), so the silent/sounding classification
 here maps straight onto the shard's letters for the phantom-highlight feature.
 
+## Public API — `result.silent_flags()`
+
+The audit's per-grapheme silence logic is shipped as a supported method
+(`quranic_phonemizer/silent.py`):
+
+```python
+pm.phonemize("101:2", stop_refs=["101:2:2"]).silent_flags()
+# [('م', False), ('ا', True), ('ٱ', True), ('ل', False), ('ق', False), ...]
+#  مَا ٱلْقَارِعَةُ → the alef of مَا is silent (iltiqaa shortens it before ٱ),
+#  the hamza wasl is silent; ل sounds.
+```
+
+Returns `list[(char, silent)]`, one entry **per written grapheme** (base letters
++ split extensions `ٰ ۥ ۦ`; maddah stays merged, e.g. `آ` is one entry), in
+reading order — the exact shape/order of the bucket TS-shard `letters[]`, so the
+consumer zips it on by index (verified 1:1 across the real Nasser fixture, 47/47
+segments). `silent` is correct for both continuous and stopping context
+(`هُدًى`: `ى` silent continuing → sounding madd-ʿiwaḍ at waqf). Extensions are
+never silent (they carry the madd); muqattaat and lafdh-jalalah use the **written
+atoms** (no synthetic dagger, no spelled-out names), unlike `tajweed_mappings()`.
+
+Cross-word idgham bridge sources are reported by their linguistic silence too;
+keeping both bridge letters highlighted (the gold bridge tile) is a rendering
+choice the consumer applies on top.
+
+

--- a/docs/silent-letter-audit.md
+++ b/docs/silent-letter-audit.md
@@ -177,11 +177,32 @@ in both contexts; the audit is **complete for continuous and stopping**.
    Finding 1 (tanween alef) to be fixed first.
 4. `idgham_shafawi` needs an explicit highlight convention (Finding 2).
 
-## Next step — bucket validation
+## Validation on real reciter stop points
 
-Validate against real reciter stop points: read where each reciter actually
-paused (from their segments in the bucket), phonemize each pause in waqf
-context, and confirm the silent/sounding split holds at *their* stops (start
-with one reciter, then scale). Tokenisation note: letter-phoneme grouping may
-differ slightly from tajweed-rule tokenisation — reconcile the two before
-splitting Timestamps cells per token.
+`dev/audit_silent_letters.py --mode detailed --detailed <reciter>/detailed.json`
+runs the same checks over a reciter's **real** recitation: each `detailed.json`
+segment's `matched_ref` span is one recited unit (its first word a real ibtidaa,
+its last word a real waqf). Validated across 5 reciters (from the
+`quranic-inspector-fixtures` dataset — the full bucket was out of the available
+token's scope):
+
+| reciter | segments | Check A | Check B | violations at actual stop words |
+|---|---|---|---|---|
+| Husary | 10,581 | 1,908 | 713 | **0** |
+| Abdul Basit | 10,257 | 1,966 | 725 | **0** |
+| Islam Sobhi | 9,661 | 1,555 | 609 | **0** |
+| Bandar Baleela | 12,543 | 1,864 | 734 | **0** |
+| Abdullah Ali Jabir | 8,800 | 2,003 | 711 | **0** |
+
+Every reciter reproduces the synthetic audit exactly: Check A is **only** the
+continuing tanween alef/maksura, Check B is **only** idgham_shafawi, and
+**zero violations land on the words where the reciter actually paused**. The
+silent-rule coverage is complete at real waqf points.
+
+## Tokenization for the highlight
+
+See [`tokenization-reconciliation.md`](tokenization-reconciliation.md): the
+bucket TS-shard `letters[]` tokenization equals the **letter-phoneme atoms**
+(proven char-for-char on a real shard), so the silent/sounding classification
+here maps straight onto the shard's letters for the phantom-highlight feature.
+

--- a/docs/tokenization-reconciliation.md
+++ b/docs/tokenization-reconciliation.md
@@ -80,3 +80,38 @@ silent flags must be derived from `letter_phoneme_mappings()`, never from
 **One genuinely ambiguous case** carries over from the silent-letter audit:
 `idgham_shafawi` (مْ+م) has two sounding graphemes sharing one merged nasal — a
 highlight convention (recommend the second/target meem) is still needed.
+
+## Can the Inspector infer silence from the shard alone? (No)
+
+Tempting alternative: skip the phonemizer at render time and hard-code a rule
+inside the Inspector off the shard's own timing — a silent letter is the one
+that shares an exact `[start,end]` with its neighbour (`dev/reconcile_tokenization.py`
+Part 3, tested against the phonemizer ground truth on the Nasser fixture):
+
+- **Completeness is fine** — every ground-truth silent grapheme IS duplicate-span
+  (0 misses). The signal finds the *cell*.
+- **But it cannot pick the sounding member.** 38 *sounding* graphemes also share a
+  span and would be wrongly skipped, because the sounding grapheme's position
+  inside a duplicate-span group is **not fixed**:
+  - silent-prefix clusters → sounding is **last**: `ٱل`, `ٱلن`, `ٱلت` (hamza wasl
+    + lam shamsiyah silent, then the sun letter sounds).
+  - base + trailing extension → sounding is **first**: `هۥ`, `ىٰ` (the base sounds,
+    the silah / dagger rides after it).
+  - and the continuing tanween alef (`ـًا`: sound→silent) puts the silent letter
+    **after** the sounding one — the opposite of `ٱل`.
+
+No positional rule separates these without re-encoding *which letters are silent*
+(hamza wasl, lam shamsiyah, tanween alef, assimilated noon, extensions, …) and
+*which phone belongs to which letter* — i.e. re-implementing the phonemizer
+inside the Inspector. The duplicate-span structure is also an **aligner
+behaviour**, not a guarantee, so depending on it is fragile.
+
+### The reconciliation, by contrast, is trivial
+
+The shard atoms equal the letter-phoneme atoms 1:1 (Part 2), and the shard-build
+path already phonemizes each segment for the cross-word bridges. So the silent
+flag is computed **once, at build time**, straight from
+`letter_phoneme_mappings()` (the phonemizer is the single source of the silence
+rules), stamped as a 4th letter slot, and the FE just reads it. No silence logic,
+and no token reconciliation, leaks into the Inspector or the FE.
+

--- a/docs/tokenization-reconciliation.md
+++ b/docs/tokenization-reconciliation.md
@@ -1,0 +1,82 @@
+# Tokenization Reconciliation — tajweed vs letter-phoneme vs the TS shard
+
+For the Timestamps-tab highlight we need to know which grapheme tokenization the
+bucket uses and how it lines up with the phonemizer's two tokenizations, so a
+silent/sounding classification can be stamped onto the bucket's letters.
+
+Reproduce with `dev/reconcile_tokenization.py [--shard <decompressed-shard.json>]`.
+
+## The three tokenizations
+
+| | atoms | extensions | lafdh jalalah (Allah) | muqattaat | silent letters |
+|---|---|---|---|---|---|
+| **`tajweed_mappings()`** | per grapheme | split (`ٰ ۥ ۦ`) | **injects a synthetic `ٰ`** for the implicit madd | **spelled out as letter names** (`أَلِف لَام`) | own entry, rule-tagged |
+| **`letter_phoneme_mappings()`** | per grapheme of the **actual written text** | split | kept as written (`ٱلله`, no synthetic char) | kept as written (`الٓمٓ`) | **grouped** into the sounding neighbour's entry |
+| **bucket TS shard `letters[]`** | per grapheme of the **actual written text** | split | kept as written | kept as written | own `[char,s,e]` entry, **same timespan** as the sounding neighbour |
+
+## Part 1 — tajweed and letter-phoneme atoms diverge (107/114 surahs)
+
+The two phonemizer tokenizations are **not** atom-identical. Across 1-114 they
+differ in exactly two constructs:
+
+- **lafdh jalalah** — 2,704 words. `tajweed_mappings()` adds a synthetic dagger
+  alef grapheme for Allah's implicit long vowel; `letter_phoneme_mappings()`
+  carries the `a:` phoneme with no extra grapheme (Rule-4 exempt).
+- **muqattaat** — 30 words. `tajweed_mappings()` returns the spelled-out letter
+  names; `letter_phoneme_mappings()` keeps the written disconnected letters.
+
+So a consumer that wants to align against the **written text** must use the
+letter-phoneme atoms (or the raw `get_mapping()` graphemes), NOT the tajweed
+tokenization.
+
+## Part 2 — the shard matches the letter-phoneme atoms (proven on real data)
+
+On the published Nasser al-Qatami fixture (`reciters/<slug>/timestamps/101.json.gz`),
+the shard's per-word `letters[]` char sequence equals the phonemizer's per-word
+grapheme sequence (base char + split extensions) **char-for-char**:
+
+```
+surah 101: segments 27/27 fully match · words 85/85 match
+surah 102: segments 20/20 fully match · words 61/61 match
+```
+
+So the **bucket letter tokenization == the letter-phoneme atoms** (per written
+grapheme, extensions split) — *not* the tajweed atoms.
+
+## How the shard already encodes the grouping
+
+The shard does not merge silent letters, but it gives a silent letter the **same
+`[start,end]` as its sounding neighbour** and emits no dedicated phone for it:
+
+```
+مَا ٱلْقَارِعَةُ →  letters ['ٱ',1927,2127] ['ل',1927,2127] …   phones ['l',1927,2127] …
+أَدْرَىٰكَ        →  letters ['ى',7250,7700] ['ٰ',7250,7700] …   phones ['aˤ:',7250,7700] …
+```
+
+That shared-timespan pair is the FE's "two letters, one cell". It is the shard's
+implicit version of the letter-phoneme **grouping** — the sounding grapheme owns
+the phone, the silent grapheme rides its span.
+
+## Implication for the silent-tag / phantom-highlight feature
+
+Because the shard atoms equal the letter-phoneme atoms 1:1, the letter-phoneme
+silent/sounding classification (`dev/audit_silent_letters.py::pronounced_in_flat`)
+maps straight onto the shard `letters[]`:
+
+- For each shard letter, mark it **silent** iff its grapheme is non-sounding in
+  the letter-phoneme view (the merged-in graphemes — hamza wasl, lam shamsiyah,
+  assimilated noon, the otiose tanween alef, the silah at waqf, …).
+- The FE skips highlighting silent-tagged letters; within a shared-timespan
+  group only the one sounding grapheme lights up.
+- Persist the flag as a 4th slot on the letter triple (`[char,s,e,silent]`) at
+  shard-build time (the build path already imports the phonemizer — see
+  QUA `qua_shared/timestamps_bridges.py` / `timestamps_pipeline.py`).
+
+**Two cases need the letter-phoneme view, not tajweed** (Part 1): the shard's
+Allah and muqattaat letters only line up with the letter-phoneme atoms, so the
+silent flags must be derived from `letter_phoneme_mappings()`, never from
+`tajweed_mappings()`.
+
+**One genuinely ambiguous case** carries over from the silent-letter audit:
+`idgham_shafawi` (مْ+م) has two sounding graphemes sharing one merged nasal — a
+highlight convention (recommend the second/target meem) is still needed.

--- a/quranic_phonemizer/phonemizer.py
+++ b/quranic_phonemizer/phonemizer.py
@@ -433,6 +433,19 @@ class PhonemizeResult:
 
         return TajweedMapping(ref=self.ref, words=tajweed_words)
 
+    def silent_flags(self) -> list[tuple[str, bool]]:
+        """Per-written-grapheme ``(char, silent)`` flags for the TS highlight.
+
+        One entry per written grapheme (base letters + split extensions) in
+        reading order — the exact shape/order of the bucket TS-shard
+        ``letters[]``, so the consumer zips it on by index. ``silent`` is the
+        linguistic fact (no audible phoneme at this grapheme's position),
+        correct for both continuous and stopping context. See
+        ``quranic_phonemizer/silent.py``.
+        """
+        from .silent import build_silent_flags
+        return build_silent_flags(self.get_mapping())
+
     def letter_phoneme_mappings(self, validate_result: bool = False) -> FlatMappingResult:
         """Build flat letter-to-phoneme mappings for forced alignment."""
         mapping = self.get_mapping()

--- a/quranic_phonemizer/silent.py
+++ b/quranic_phonemizer/silent.py
@@ -1,0 +1,94 @@
+"""
+Per-grapheme silent flags for the Timestamps highlight.
+
+A phoneme is written with several graphemes but only one is pronounced; the rest
+are silent (hamza wasl, lam shamsiyah, the otiose tanween alef, an assimilated
+noon, …). The Inspector Timestamps tab splits every letter into its own cell and
+highlights the cell being uttered — so it needs, per written grapheme, whether
+that grapheme is silent (skip it) or sounding (highlight it).
+
+``build_silent_flags`` returns one ``(char, silent)`` pair per written grapheme
+(base letters + split extensions) in reading order — the exact order and
+tokenization of the bucket TS-shard ``letters[]`` (proven 1:1 against a real
+shard). The consumer zips it straight onto the shard letters.
+
+``silent`` is the *linguistic* fact: the grapheme produces no audible phoneme at
+its own position in the final (post-redistribution) output. Extensions are never
+silent — they carry the madd. Cross-word idgham mergers are reported by their
+linguistic silence too; keeping both bridge letters highlighted is a rendering
+choice the consumer applies on top (it already owns the bridge tile).
+
+``sounding_in_flat`` mirrors the two redistributions the flat builder applies on
+top of the raw per-letter phonemes, so the flag is correct for BOTH continuous
+and stopping recitation:
+  - iltiqaa: a shortened long vowel before hamza wasl moves to the preceding
+    consonant; the vowel letter goes silent.
+  - waqf tanween: when stopping, the long vowel moves from the tanween consonant
+    onto the otherwise-silent alef / alef-maksura, which becomes the carrier.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from .tajweed_rule import TajweedRule
+from .letter_phoneme_mapping import TANWEEN_DIACRITICS, get_full_char
+from .mapping import PhonemizationMapping, WordMapping
+
+# Extension graphemes the bucket TS-shard splits into their OWN ``letters[]``
+# entry: dagger alef, mini waw, mini yaa. The maddah (ٓ U+0653) and other
+# combining marks stay merged with their base letter (so آ = ا+ٓ is one entry),
+# matching the aligner's tokenization exactly.
+_SPLIT_EXTENSIONS = {"ٰ", "ۥ", "ۦ"}  # ٰ ۥ ۦ
+
+# A long vowel shortened before hamza wasl is stored on the vowel letter as one
+# of these short vowels, then moved to the preceding consonant by the flat builder.
+_SHORT_VOWELS = {"a", "aˤ", "u", "i"}
+
+
+def sounding_in_flat(word: WordMapping, li: int) -> bool:
+    """Whether the letter at ``li`` contributes an audible phoneme at its own
+    grapheme position in the final flat output (i.e. is a highlight target)."""
+    lm = word.letter_mappings[li]
+    if lm.phonemes:
+        src = {t.rule for t in lm.tajweed_rules if t.is_source}
+        if (TajweedRule.SILENT_ILTIQAA_SAKINAYN in src
+                and len(lm.phonemes) == 1 and lm.phonemes[0] in _SHORT_VOWELS):
+            return False  # demoted to the preceding consonant
+        return True
+    # raw-silent: the waqf-tanween redistribution target becomes the madd carrier
+    if word.is_stopping and lm.char in ("ا", "ى") and li > 0:
+        prev = word.letter_mappings[li - 1]
+        if (prev.diacritic in TANWEEN_DIACRITICS
+                and prev.phonemes and ":" in prev.phonemes[-1]):
+            return True
+    return False
+
+
+def build_silent_flags(mapping: PhonemizationMapping) -> List[Tuple[str, bool]]:
+    """``[(char, silent), ...]`` — one per written grapheme, in reading order.
+
+    Base letters carry their sounding/silent fact; extensions (dagger alef,
+    maddah, mini waw/yaa) are written madd graphemes and are never silent.
+    """
+    flags: List[Tuple[str, bool]] = []
+    for word in mapping.words:
+        for li, lm in enumerate(word.letter_mappings):
+            silent = not sounding_in_flat(word, li)
+            # Walk base+extensions in textual order, splitting only the
+            # standalone extension graphemes; the run carrying the base letter
+            # keeps the letter's silent flag, split extensions always sound.
+            cur = ""
+            base_pending = True  # the run carrying the base letter owns ``silent``
+            for ch in get_full_char(lm):
+                if ch in _SPLIT_EXTENSIONS:
+                    if cur:
+                        flags.append((cur, silent if base_pending else False))
+                        base_pending = False
+                        cur = ""
+                    flags.append((ch, False))
+                else:
+                    cur += ch
+            if cur:
+                flags.append((cur, silent if base_pending else False))
+    return flags


### PR DESCRIPTION
## What

Adds `result.silent_flags()` — a per-written-grapheme silent/sounding classification so a consumer (the Inspector Timestamps tab) can highlight only the **one** grapheme that is actually pronounced per phoneme, instead of lighting up the whole silent cluster (hamza wasl, lam shamsiyah, the otiose tanween alef, an assimilated noon, …). It returns `list[(char, silent)]`, one entry per written grapheme (base letters + split extensions `ٰ ۥ ۦ`; maddah stays merged, so `آ` is one entry), in reading order — the exact shape and order of the bucket TS-shard `letters[]`, so the consumer zips it on by index.

## How it was derived

The classification is grounded in a full audit of letter→phoneme silence across the whole muṣḥaf. Continuous (77k words) + 50k random waqf stops + the real stop points of 5 reciters (≈51k recited segments) all agree: the silent-rule coverage is comprehensive, with exactly two characterised cases — the continuing **tanween alef/maksura** is silent but carries no tajweed rule (it flips to the sounding madd-ʿiwaḍ carrier at waqf), and **idgham_shafawi** is the only genuinely two-sounding cell. The audit also reconciles tokenizations: `tajweed_mappings()` diverges from the written text at lafdh-jalalah (synthetic dagger-alef) and muqattaat (spelled-out names), whereas the shard `letters[]` matches the **letter-phoneme atoms** char-for-char (proven 1:1 on a real published shard, 47/47 segments). `silent_flags()` is therefore built on the letter-phoneme machinery (`quranic_phonemizer/silent.py`), is correct for both continuous and stopping context, and uses the written atoms so it lines up with the shard where tajweed would not.

## Scope

Shipped wheel impact is the new `silent.py` module + the `silent_flags()` method on `PhonemizeResult`; everything else is non-shipped `dev/` tooling (the audit, the tokenization reconciliation, and the multi-grapheme cell catalogue) plus `docs/` findings. Cross-word idgham bridge sources are reported by their linguistic silence — keeping both bridge letters highlighted (the gold bridge tile) is a rendering choice the consumer applies on top, so no UI policy leaks into the package.

https://claude.ai/code/session_01Mh5eSzK2L4PetyB8DjMa1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mh5eSzK2L4PetyB8DjMa1U)_