### PR TITLE
feat(silent): silah-on-stop silence + surface silence marks

### DIFF
--- a/quranic_phonemizer/phonemizer.py
+++ b/quranic_phonemizer/phonemizer.py
@@ -433,14 +433,15 @@ class PhonemizeResult:
 
         return TajweedMapping(ref=self.ref, words=tajweed_words)
 
-    def silent_flags(self) -> list[tuple[str, bool]]:
-        """Per-written-grapheme ``(char, silent)`` flags for the TS highlight.
+    def silent_flags(self) -> list[tuple[str, bool, str]]:
+        """Per-written-grapheme ``(char, silent, mark)`` flags for the TS highlight.
 
         One entry per written grapheme (base letters + split extensions) in
         reading order — the exact shape/order of the bucket TS-shard
         ``letters[]``, so the consumer zips it on by index. ``silent`` is the
         linguistic fact (no audible phoneme at this grapheme's position),
-        correct for both continuous and stopping context. See
+        correct for both continuous and stopping context; ``mark`` is the
+        silence combining mark above the grapheme (U+06DF / U+06E0) or ``""``. See
         ``quranic_phonemizer/silent.py``.
         """
         from .silent import build_silent_flags

--- a/quranic_phonemizer/silent.py
+++ b/quranic_phonemizer/silent.py
@@ -7,16 +7,22 @@ noon, …). The Inspector Timestamps tab splits every letter into its own cell a
 highlights the cell being uttered — so it needs, per written grapheme, whether
 that grapheme is silent (skip it) or sounding (highlight it).
 
-``build_silent_flags`` returns one ``(char, silent)`` pair per written grapheme
-(base letters + split extensions) in reading order — the exact order and
+``build_silent_flags`` returns one ``(char, silent, mark)`` triple per written
+grapheme (base letters + split extensions) in reading order — the exact order and
 tokenization of the bucket TS-shard ``letters[]`` (proven 1:1 against a real
-shard). The consumer zips it straight onto the shard letters.
+shard). The consumer zips it straight onto the shard letters. ``char`` is bare
+(matches the shard); ``mark`` is the silence-indicating combining mark written
+above the grapheme (the SILENT_ALWAYS / SILENT_AT_CONTINUATION small-zero,
+U+06DF / U+06E0) or ``""`` — surfaced from ``other_symbols`` (which
+``get_full_char`` omits) so the consumer can render it on the grapheme.
 
 ``silent`` is the *linguistic* fact: the grapheme produces no audible phoneme at
-its own position in the final (post-redistribution) output. Extensions are never
-silent — they carry the madd. Cross-word idgham mergers are reported by their
-linguistic silence too; keeping both bridge letters highlighted is a rendering
-choice the consumer applies on top (it already owns the bridge tile).
+its own position in the final (post-redistribution) output. The dagger alef
+(U+0670) is an unconditional madd and always sounds; the silah (mini waw/yaa,
+U+06E5/U+06E6) is a conditional madd that drops at waqf, so it is silent only when
+its word stops. Cross-word idgham mergers are reported by their linguistic silence
+too; keeping both bridge letters highlighted is a rendering choice the consumer
+applies on top (it already owns the bridge tile).
 
 ``sounding_in_flat`` mirrors the two redistributions the flat builder applies on
 top of the raw per-letter phonemes, so the flag is correct for BOTH continuous
@@ -45,6 +51,23 @@ _SPLIT_EXTENSIONS = {"ٰ", "ۥ", "ۦ"}  # ٰ ۥ ۦ
 # of these short vowels, then moved to the preceding consonant by the flat builder.
 _SHORT_VOWELS = {"a", "aˤ", "u", "i"}
 
+# The silah (mini waw / mini yaa, U+06E5 / U+06E6) is a conditional madd —
+# pronounced in wasl, dropped at waqf — so it is silent only when its word stops.
+# The dagger alef (U+0670, the third split extension) is an unconditional madd that
+# always sounds.
+_SILAH_EXTENSIONS = {"ۥ", "ۦ"}
+
+
+def _silent_mark(lm) -> str:
+    """The silence-indicating combining mark above ``lm`` (the SILENT_ALWAYS /
+    SILENT_AT_CONTINUATION small-zero, U+06DF / U+06E0), or ``""``. It lives in
+    ``other_symbols`` — which ``get_full_char`` omits — so the highlight can render
+    it on the grapheme."""
+    for sym in getattr(lm, "other_symbols", None) or []:
+        if sym.name.startswith("SILENT"):
+            return sym.char
+    return ""
+
 
 def sounding_in_flat(word: WordMapping, li: int) -> bool:
     """Whether the letter at ``li`` contributes an audible phoneme at its own
@@ -65,30 +88,33 @@ def sounding_in_flat(word: WordMapping, li: int) -> bool:
     return False
 
 
-def build_silent_flags(mapping: PhonemizationMapping) -> List[Tuple[str, bool]]:
-    """``[(char, silent), ...]`` — one per written grapheme, in reading order.
+def build_silent_flags(mapping: PhonemizationMapping) -> List[Tuple[str, bool, str]]:
+    """``[(char, silent, mark), ...]`` — one per written grapheme, in reading order.
 
-    Base letters carry their sounding/silent fact; extensions (dagger alef,
-    maddah, mini waw/yaa) are written madd graphemes and are never silent.
+    ``char`` is the bare grapheme (base letter or split extension) matching the
+    shard tokenization; ``silent`` its linguistic silence at its own position;
+    ``mark`` the silence-indicating combining mark above it (or ``""``). The run
+    carrying the base letter owns the base ``silent`` and ``mark``; the dagger
+    alef madd always sounds while the silah drops at waqf.
     """
-    flags: List[Tuple[str, bool]] = []
+    flags: List[Tuple[str, bool, str]] = []
     for word in mapping.words:
         for li, lm in enumerate(word.letter_mappings):
             silent = not sounding_in_flat(word, li)
-            # Walk base+extensions in textual order, splitting only the
-            # standalone extension graphemes; the run carrying the base letter
-            # keeps the letter's silent flag, split extensions always sound.
+            mark = _silent_mark(lm)
             cur = ""
-            base_pending = True  # the run carrying the base letter owns ``silent``
+            base_pending = True  # the run carrying the base letter owns silent+mark
             for ch in get_full_char(lm):
                 if ch in _SPLIT_EXTENSIONS:
                     if cur:
-                        flags.append((cur, silent if base_pending else False))
+                        flags.append((cur, silent if base_pending else False,
+                                      mark if base_pending else ""))
                         base_pending = False
                         cur = ""
-                    flags.append((ch, False))
+                    flags.append((ch, ch in _SILAH_EXTENSIONS and word.is_stopping, ""))
                 else:
                     cur += ch
             if cur:
-                flags.append((cur, silent if base_pending else False))
+                flags.append((cur, silent if base_pending else False,
+                              mark if base_pending else ""))
     return flags


### PR DESCRIPTION
`build_silent_flags` / `silent_flags()` now return `(char, silent, mark)` triples.

- **Silah-on-stop:** the silah (mini waw/yaa, U+06E5/U+06E6) is a conditional madd — pronounced in wasl, dropped at waqf — so it is now `silent` only when its word stops (the phonemizer already sets `is_stopping` on the last word of a ref). The dagger alef (U+0670) stays an unconditional madd (never silent).
- **Silence marks:** the SILENT_ALWAYS / SILENT_AT_CONTINUATION combining mark (U+06DF/U+06E0) — which `get_full_char` drops — is surfaced from `other_symbols` as the 3rd tuple element, so the Timestamps highlight can render it on the grapheme (e.g. the otiose jama'a alef shows its `۟`).

`char` stays bare so the shard char-match guard is unaffected. 178 local tests pass incl. new silah/mark cases.