### PR TITLE
feat: add character_phoneme_mappings() per-character cell API

### DIFF
--- a/.claude/skills/quranic-phonemizer/SKILL.md
+++ b/.claude/skills/quranic-phonemizer/SKILL.md
@@ -25,6 +25,7 @@ Consult existing documentation before answering questions — avoid duplicating 
 | Full API & usage | `.claude/skills/quranic-phonemizer/references/README.md` | Installation, input refs, text search, outputs, stops, phonetic text, tajweed mappings, letter-phoneme mappings, phoneme inventory |
 | Tajweed mapping spec | `.claude/skills/quranic-phonemizer/references/tajweed-mappings.md` | Output structure, source/target rules, all 33 rule definitions, multi-rule overlap, stopping effects, muqattaat, serialization |
 | Letter-phoneme mapping spec | `.claude/skills/quranic-phonemizer/references/letter-phoneme-mappings.md` | Merge rules (PREV/NEXT/CROSS-WORD), extension splitting, stopping effects, validation rules, serialization |
+| Character-phoneme mapping spec | `.claude/skills/quranic-phonemizer/references/character-phoneme-mappings.md` | Per-character (haraka/tanween) cells, roles/statuses/tags, the word-local `phoneme_indices` timing invariant, share groups, implicit/dropped/replaced/shortened families, serialization |
 | Tajweed linguistics | `.claude/skills/quranic-phonemizer/references/tajweed-linguistics.md` | What tajweed is, rule categories, how rules affect pronunciation — for those unfamiliar with Arabic phonetics |
 | DB build / risk register | `dev/README.md` | How `dev/Quran.json` + `surah_info.json` produce `quran_db.bin`, safe vs dangerous edits, CI sync workflow |
 | Phoneme config | `quranic_phonemizer/resources/base_phonemes.yaml` | Character-to-phoneme YAML definitions |
@@ -97,6 +98,21 @@ result.save("out.json", fmt="letter_phoneme")
 
 Returns `FlatMappingResult`. For merge rules, extension splitting, stopping effects, and validation, see `docs/letter-phoneme-mappings.md`.
 
+### Character-Phoneme Mappings
+
+One cell per written character (base letter, each haraka/tanween, the long-vowel carrier) plus rule-inserted implicit units (hamza-waṣl vowel, iltiqāʾ kasra, Allah dagger-alef, madd-ʿiwaḍ alef). Each cell carries word-local `phoneme_indices` for per-diacritic highlight timing. Canonical domain only — no script/visual details.
+
+```python
+cpm = result.character_phoneme_mappings()
+for word in cpm.words:
+    for c in word.cells:                                       # Cell: chars, role, status,
+        print(c.chars, c.role, c.status, c.phonemes, c.phoneme_indices, c.tag, c.share_group)
+violations = cpm.validate()                                    # empty = valid
+result.save("out.json", fmt="char_phoneme")
+```
+
+Returns `CharPhonemeResult` (`words: List[CharWord]`, each with `cells: List[Cell]`). Roles `base/haraka/tanween/madd`; statuses `present/inserted/dropped/replaced/shortened`. For the full family table, the `phoneme_indices` invariant, share groups, and serialization, see `docs/character-phoneme-mappings.md`.
+
 ### PhonemeRegistry (Runtime Customization)
 
 Singleton that caches YAML phoneme definitions and supports runtime overrides:
@@ -119,6 +135,7 @@ LetterMapping, WordMapping, AlignmentEntry, PhonemizationMapping
 TajweedRule, TajweedRuleTag
 TajweedMapping, TajweedWordMapping, TajweedEntry
 FlatMappingResult
+Cell, CharWord, CharPhonemeResult
 ```
 
 ## Architecture Overview

--- a/.claude/skills/quranic-phonemizer/SKILL.md
+++ b/.claude/skills/quranic-phonemizer/SKILL.md
@@ -136,6 +136,10 @@ TajweedRule, TajweedRuleTag
 TajweedMapping, TajweedWordMapping, TajweedEntry
 FlatMappingResult
 Cell, CharWord, CharPhonemeResult
+CellRole, CellStatus                                   # cell vocab enums (consumers codegen/mirror these)
+MergerClass, detect_cross_word_mergers                 # the single cross-word merger classifier
+is_madd, is_geminate, is_nasalised, is_render_only     # phoneme predicates (YAML-derived)
+BRIDGE_RULE_VALUES, MERGER_ON_PREV_VALUES, TANWEEN_ASSIMILATES_VALUES, diacritic_chars
 ```
 
 ## Architecture Overview

--- a/.claude/skills/quranic-phonemizer/references/character-phoneme-mappings.md
+++ b/.claude/skills/quranic-phonemizer/references/character-phoneme-mappings.md
@@ -1,0 +1,159 @@
+# Character-Phoneme Mappings
+
+Character-phoneme mappings provide one **cell per written character** — base letter,
+each haraka / tanween, the long-vowel carrier — plus the rule-inserted *implicit* units
+(hamza-waṣl connecting vowel, iltiqāʾ kasra, the Allah dagger-alef, the madd-ʿiwaḍ alef).
+Each cell carries the phoneme(s) it sounds and their indices, so a forced aligner's
+per-phoneme timestamps can drive **per-diacritic** highlighting.
+
+This is the finer, character-level companion to [letter-phoneme-mappings](letter-phoneme-mappings.md)
+(which aligns one entry per *letter*). It is additive — it changes nothing about the
+letter-phoneme, silent, or tajweed outputs.
+
+```python
+from quranic_phonemizer import Phonemizer
+
+pm = Phonemizer()
+result = pm.phonemize("1:1")
+cpm = result.character_phoneme_mappings()
+for word in cpm.words:
+    print(word.location, word.text)
+    for c in word.cells:
+        print(f"  {c.chars!r:5} {c.role:8} {c.status:9} {c.phonemes} idx={c.phoneme_indices}")
+```
+
+## Design principle — canonical domain only
+
+A cell carries **only canonical domain facts**: its role, status, the phonemes it sounds,
+their indices, and a tajweed-rule `tag`. It carries **no script/visual details** — no glyph
+codes, no open/closed/iqlāb tanween form, no above/below placement. A consumer (e.g. the
+Inspector) derives all of that from the `tag` + the diacritic char. This keeps the
+phonemizer the single source of recitation domain knowledge and lets each renderer own its
+own script conventions (e.g. the Digital Khatt mini-meem for iqlāb).
+
+## Output structure
+
+```
+CharPhonemeResult
+├── ref: str
+├── mapping: PhonemizationMapping        # the underlying full mapping (for validation)
+└── words: List[CharWord]
+        ├── location, text, is_starting, is_stopping
+        └── cells: List[Cell]
+```
+
+### Cell
+
+| Field | Meaning |
+|-------|---------|
+| `chars` | the canonical source character(s); `""` if the cell is fully implicit |
+| `role` | `base` · `haraka` · `tanween` · `madd` |
+| `status` | `present` · `inserted` · `dropped` · `replaced` · `shortened` |
+| `phonemes` | the phoneme strings this cell sounds (`[]` if silent) |
+| `phoneme_indices` | **word-local** indices into the word's phoneme sequence — the timing anchor |
+| `tag` | canonical case/rule key the consumer switches on (see below); else `null` |
+| `share_group` | cells with the same id share timing / highlight together; else `null` |
+| `source_letter_index` | the letter this cell sits on/after; `-1` if fully implicit |
+| `source_letter_indices` | every contributing letter index |
+
+**Roles** — `base` = consonant / consonantal vowel-letter / hamza / hamza-waṣl;
+`haraka` = fatḥa/ḍamma/kasra/sukūn; `tanween` = fatḥatān/ḍammatān/kasratān;
+`madd` = long-vowel carrier (`ا و ي ى`, mini `ۥ ۦ ۧ`, dagger-alef `ٰ`).
+
+**Statuses** — `present` (explicit, sounded); `inserted` (implicit, no source char);
+`dropped` (char present but silent in this context — render greyed); `replaced` (sound
+changed from the written form, e.g. madd-ʿiwaḍ); `shortened` (long vowel reduced, carrier
+silenced — iltiqāʾ).
+
+**Tags** — the tajweed rule for rule-driven cases (`iqlab_tanween`, `ikhfaa_tanween`,
+`idgham_ghunnah_tanween`, `idgham_bila_ghunnah_tanween`, `ikhfaa_noon`, …) and a small set
+of structural keys: `hamza_wasl_vowel`, `iltiqaa_kasra`, `iltiqaa`, `madd_iwad`,
+`allah_dagger_alef`, `qalqala`.
+
+## The `phoneme_indices` invariant
+
+`phoneme_indices` are taken from the **raw per-letter walk** (the same order as
+`word.phonemes` and a forced aligner's per-word phones), never a redistributed view.
+Iltiqāʾ demotion and waqf-tanween redistribution change which *cell displays* a phoneme,
+never the phoneme's index. An index referenced by more than one cell is always an
+intentional **shared-timing group** (e.g. a long vowel's haraka + carrier), flagged with
+`share_group`. `validate()` enforces: every index covered ≥1×, shared indices share one
+group, every diacritic char has a cell, and each cell's phoneme equals the resolved
+phoneme at its index.
+
+## Families (worked examples)
+
+### Simple haraka — `بِسْمِ` (1:1:1)
+```
+'ب'  base    present  ['b'] idx=[0]
+'ِ'  haraka  present  ['i'] idx=[1]
+```
+
+### Long vowel — haraka + carrier share the vowel (`ٱلرَّحِيمِ`, continue)
+```
+'ح'  base    present  ['ħ']  idx=[4]
+'ِ'  haraka  present  ['i:'] idx=[5] share_group=G   ← both reference idx 5
+'ي'  madd    present  ['i:'] idx=[5] share_group=G
+```
+Same for an extension carrier (`ٱلرَّحْمَـٰنِ` → `م`=`m`, fatḥa & dagger-alef `ٰ` share `a:`).
+
+### Tanween (closed, continue)
+```
+# izhar  عَذَابٌ ع…     'ٌ' tanween present ['u','n']
+# ikhfaa/iqlab أَلِيمٌ ب… 'ٌ' tanween present ['u','ŋ']  tag=iqlab_tanween
+# idgham  هُدًى لِّـ…    'ً' tanween present ['a']        tag=idgham_bila_ghunnah_tanween share_group=G
+#                        + next word 'لّ' base ['ll'] share_group=G   (cross-word co-highlight)
+```
+
+### Tanween + iltiqāʾ kasra (continue) — `خَيْرٌ ٱ…`
+```
+'ٌ'  tanween  present  ['u','n'] idx=[4,5]
+''   haraka   inserted ['i']     idx=[6]  tag=iltiqaa_kasra     ← graphemeless bridge kasra
+```
+
+### Stopping — tanween dropped / madd-ʿiwaḍ
+```
+# عَظِيمٌ⏹   'ٌ' tanween dropped []            (dammatan/kasratan vanish at waqf)
+# هُدًى⏹     'ً' tanween dropped [] tag=madd_iwad
+#            'ى' madd    replaced ['a:'] tag=madd_iwad   (the long ā moves onto the alef-maksura)
+```
+
+### Hamza-waṣl pronounced (start) — `ٱلْحَمْدُ`
+```
+'ٱ'  base    present  ['ʔ'] idx=[0]
+''   haraka  inserted ['a'] idx=[1] tag=hamza_wasl_vowel   ← connecting vowel, no grapheme
+```
+
+### Allah — implicit dagger-alef — `ٱللَّهِ`
+```
+'ل'  base    present  ['lˤlˤ'] idx=[2]
+''   madd    inserted ['aˤ:']  idx=[3] tag=allah_dagger_alef
+```
+
+### Iltiqāʾ shortening (continue) — `فِى ٱل…`
+```
+'ف'  base    present   ['f'] idx=[0]
+'ِ'  haraka  shortened ['i'] idx=[1] tag=iltiqaa   ← short vowel attaches to the base
+'ى'  madd    shortened []                          ← carrier silenced
+```
+
+### Muqaṭṭaʿāt — `الٓمٓ` (2:1:1)
+```
+'ا'  base  present  ['ʔ','a','l','i','f']   ← one char, five phonemes
+'لٓ' base  present  ['l','a:']
+'مٓ' base  present  ['m̃','i:','m']
+```
+
+## Serialization
+
+```python
+cpm = result.character_phoneme_mappings()
+cpm.to_dict()                      # nested dict (named fields)
+cpm.to_list()                      # [[cell-as-list, ...] per word]
+cpm.to_json(indent=2)
+cpm.validate()                     # [] = valid
+cpm.save("out.json")
+result.save("out.json", fmt="char_phoneme")
+```
+
+Run with `result.character_phoneme_mappings(validate_result=True)` to raise on any violation.

--- a/.claude/skills/quranic-phonemizer/references/character-phoneme-mappings.md
+++ b/.claude/skills/quranic-phonemizer/references/character-phoneme-mappings.md
@@ -31,6 +31,13 @@ Inspector) derives all of that from the `tag` + the diacritic char. This keeps t
 phonemizer the single source of recitation domain knowledge and lets each renderer own its
 own script conventions (e.g. the Digital Khatt mini-meem for iqlāb).
 
+So the consumer never has to inspect the phonemes themselves, two facts that would
+otherwise require phonology are folded into the cell: a **geminated** base composes the
+canonical shaddah `ّ` into its `chars` (the consumer renders the text verbatim), and an
+**idgham-shafawi** haraka whose vowel the merged base absorbs stays `present` — carrying the
+base's `phoneme_indices` + a `share_group` — so the consumer co-lights it on the merger
+rather than greying it out.
+
 ## Output structure
 
 ```
@@ -46,7 +53,7 @@ CharPhonemeResult
 
 | Field | Meaning |
 |-------|---------|
-| `chars` | the canonical source character(s); `""` if the cell is fully implicit |
+| `chars` | the canonical source character(s) — includes a composed shaddah `ّ` on a geminated base; `""` if the cell is fully implicit |
 | `role` | `base` · `haraka` · `tanween` · `madd` |
 | `status` | `present` · `inserted` · `dropped` · `replaced` · `shortened` |
 | `phonemes` | the phoneme strings this cell sounds (`[]` if silent) |
@@ -87,6 +94,12 @@ phoneme at its index.
 ```
 'ب'  base    present  ['b'] idx=[0]
 'ِ'  haraka  present  ['i'] idx=[1]
+```
+
+### Geminate — shaddah composed into `chars` (`رَبِّ`)
+```
+'ر'   base    present  ['rˤ'] idx=[0]
+'بّ'  base    present  ['bb'] idx=[2]   ← canonical shaddah ◌ّ folded into chars
 ```
 
 ### Long vowel — haraka + carrier share the vowel (`ٱلرَّحِيمِ`, continue)

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.worktrees/
 __pycache__/
 .pytest_cache
 *.py[cod]

--- a/docs/character-phoneme-mappings.md
+++ b/docs/character-phoneme-mappings.md
@@ -129,6 +129,9 @@ Same for an extension carrier (`ٱلرَّحْمَـٰنِ` → `م`=`m`, fatḥ
 # عَظِيمٌ⏹   'ٌ' tanween dropped []            (dammatan/kasratan vanish at waqf)
 # هُدًى⏹     'ً' tanween dropped [] tag=madd_iwad
 #            'ى' madd    replaced ['a:'] tag=madd_iwad   (the long ā moves onto the alef-maksura)
+# مَآءً⏹     'ً' tanween dropped [] tag=madd_iwad
+#            ''  madd    inserted ['a:'] tag=madd_iwad   (no written carrier — word ends in hamza;
+#                                                         the ʿiwaḍ alef is implicit, like the dagger-alef)
 ```
 
 ### Hamza-waṣl pronounced (start) — `ٱلْحَمْدُ`

--- a/docs/character-phoneme-mappings.md
+++ b/docs/character-phoneme-mappings.md
@@ -72,10 +72,21 @@ CharPhonemeResult
 changed from the written form, e.g. madd-ʿiwaḍ); `shortened` (long vowel reduced, carrier
 silenced — iltiqāʾ).
 
-**Tags** — the tajweed rule for rule-driven cases (`iqlab_tanween`, `ikhfaa_tanween`,
-`idgham_ghunnah_tanween`, `idgham_bila_ghunnah_tanween`, `ikhfaa_noon`, …) and a small set
-of structural keys: `hamza_wasl_vowel`, `iltiqaa_kasra`, `iltiqaa`, `madd_iwad`,
-`allah_dagger_alef`, `qalqala`.
+**Tags** — the tajweed rule a consumer switches on. A cell carries at most one:
+
+- **Nūn/tanwīn rules** (on the `base` nūn or the `tanween` cell): `ikhfaa_noon`/`ikhfaa_tanween`,
+  `iqlab_noon`/`iqlab_tanween`, `idgham_ghunnah_noon`/`idgham_ghunnah_tanween`,
+  `idgham_bila_ghunnah_noon`/`idgham_bila_ghunnah_tanween`.
+- **Meem-sākin + plain ghunnah** (on the `base` mīm/nūn): `ikhfaa_shafawi`, `idgham_shafawi`
+  (also share-grouped cross-word to the receiving mīm), `noon_ghunnah`/`meem_ghunnah` (mushaddad
+  نّ/مّ).
+- **Madd subtype** — tags the long-vowel **carrier** grapheme cell (not its haraka, which
+  co-lights via `share_group` but stays untagged): `madd_wajib_muttasil`, `madd_jaiz_munfasil`,
+  `madd_lazim`, `madd_arid_lissukun`, `madd_leen` (on the و/ي base). Regular ṭabīʿī carries **no
+  tag**. Source: `word.madd_mappings[*].madd_type` (NOT the letter's `tajweed_rules`).
+- **Structural keys**: `hamza_wasl_vowel`, `iltiqaa_kasra`, `iltiqaa`, `madd_iwad`,
+  `allah_dagger_alef`, `qalqala`. Exception: the Allah dagger-alef becomes ʿāriḍ at waqf, so its
+  cell carries `madd_arid_lissukun` when stopping and `allah_dagger_alef` when continuing.
 
 ## The `phoneme_indices` invariant
 
@@ -133,6 +144,14 @@ Same for an extension carrier (`ٱلرَّحْمَـٰنِ` → `م`=`m`, fatḥ
 #            ''  madd    inserted ['a:'] tag=madd_iwad   (no written carrier — word ends in hamza;
 #                                                         the ʿiwaḍ alef is implicit, like the dagger-alef)
 ```
+
+### Madd subtype — tags the carrier, not the haraka — `جَآءَ` (wajib muttasil)
+```
+'آ'  madd    present  ['a:'] idx=[1] tag=madd_wajib_muttasil   ← the long-vowel carrier
+'َ'  haraka  present  ['a:'] idx=[1] share_group=…             ← co-lights, but NO tag (no colour)
+```
+The haraka and carrier share the one `a:` index (so they co-highlight); only the carrier
+grapheme carries the madd subtype. Leen tags the و/ي `base` instead (`خَوْفٍ⏹` → و `madd_leen`).
 
 ### Hamza-waṣl pronounced (start) — `ٱلْحَمْدُ`
 ```

--- a/docs/character-phoneme-mappings.md
+++ b/docs/character-phoneme-mappings.md
@@ -1,0 +1,159 @@
+# Character-Phoneme Mappings
+
+Character-phoneme mappings provide one **cell per written character** — base letter,
+each haraka / tanween, the long-vowel carrier — plus the rule-inserted *implicit* units
+(hamza-waṣl connecting vowel, iltiqāʾ kasra, the Allah dagger-alef, the madd-ʿiwaḍ alef).
+Each cell carries the phoneme(s) it sounds and their indices, so a forced aligner's
+per-phoneme timestamps can drive **per-diacritic** highlighting.
+
+This is the finer, character-level companion to [letter-phoneme-mappings](letter-phoneme-mappings.md)
+(which aligns one entry per *letter*). It is additive — it changes nothing about the
+letter-phoneme, silent, or tajweed outputs.
+
+```python
+from quranic_phonemizer import Phonemizer
+
+pm = Phonemizer()
+result = pm.phonemize("1:1")
+cpm = result.character_phoneme_mappings()
+for word in cpm.words:
+    print(word.location, word.text)
+    for c in word.cells:
+        print(f"  {c.chars!r:5} {c.role:8} {c.status:9} {c.phonemes} idx={c.phoneme_indices}")
+```
+
+## Design principle — canonical domain only
+
+A cell carries **only canonical domain facts**: its role, status, the phonemes it sounds,
+their indices, and a tajweed-rule `tag`. It carries **no script/visual details** — no glyph
+codes, no open/closed/iqlāb tanween form, no above/below placement. A consumer (e.g. the
+Inspector) derives all of that from the `tag` + the diacritic char. This keeps the
+phonemizer the single source of recitation domain knowledge and lets each renderer own its
+own script conventions (e.g. the Digital Khatt mini-meem for iqlāb).
+
+## Output structure
+
+```
+CharPhonemeResult
+├── ref: str
+├── mapping: PhonemizationMapping        # the underlying full mapping (for validation)
+└── words: List[CharWord]
+        ├── location, text, is_starting, is_stopping
+        └── cells: List[Cell]
+```
+
+### Cell
+
+| Field | Meaning |
+|-------|---------|
+| `chars` | the canonical source character(s); `""` if the cell is fully implicit |
+| `role` | `base` · `haraka` · `tanween` · `madd` |
+| `status` | `present` · `inserted` · `dropped` · `replaced` · `shortened` |
+| `phonemes` | the phoneme strings this cell sounds (`[]` if silent) |
+| `phoneme_indices` | **word-local** indices into the word's phoneme sequence — the timing anchor |
+| `tag` | canonical case/rule key the consumer switches on (see below); else `null` |
+| `share_group` | cells with the same id share timing / highlight together; else `null` |
+| `source_letter_index` | the letter this cell sits on/after; `-1` if fully implicit |
+| `source_letter_indices` | every contributing letter index |
+
+**Roles** — `base` = consonant / consonantal vowel-letter / hamza / hamza-waṣl;
+`haraka` = fatḥa/ḍamma/kasra/sukūn; `tanween` = fatḥatān/ḍammatān/kasratān;
+`madd` = long-vowel carrier (`ا و ي ى`, mini `ۥ ۦ ۧ`, dagger-alef `ٰ`).
+
+**Statuses** — `present` (explicit, sounded); `inserted` (implicit, no source char);
+`dropped` (char present but silent in this context — render greyed); `replaced` (sound
+changed from the written form, e.g. madd-ʿiwaḍ); `shortened` (long vowel reduced, carrier
+silenced — iltiqāʾ).
+
+**Tags** — the tajweed rule for rule-driven cases (`iqlab_tanween`, `ikhfaa_tanween`,
+`idgham_ghunnah_tanween`, `idgham_bila_ghunnah_tanween`, `ikhfaa_noon`, …) and a small set
+of structural keys: `hamza_wasl_vowel`, `iltiqaa_kasra`, `iltiqaa`, `madd_iwad`,
+`allah_dagger_alef`, `qalqala`.
+
+## The `phoneme_indices` invariant
+
+`phoneme_indices` are taken from the **raw per-letter walk** (the same order as
+`word.phonemes` and a forced aligner's per-word phones), never a redistributed view.
+Iltiqāʾ demotion and waqf-tanween redistribution change which *cell displays* a phoneme,
+never the phoneme's index. An index referenced by more than one cell is always an
+intentional **shared-timing group** (e.g. a long vowel's haraka + carrier), flagged with
+`share_group`. `validate()` enforces: every index covered ≥1×, shared indices share one
+group, every diacritic char has a cell, and each cell's phoneme equals the resolved
+phoneme at its index.
+
+## Families (worked examples)
+
+### Simple haraka — `بِسْمِ` (1:1:1)
+```
+'ب'  base    present  ['b'] idx=[0]
+'ِ'  haraka  present  ['i'] idx=[1]
+```
+
+### Long vowel — haraka + carrier share the vowel (`ٱلرَّحِيمِ`, continue)
+```
+'ح'  base    present  ['ħ']  idx=[4]
+'ِ'  haraka  present  ['i:'] idx=[5] share_group=G   ← both reference idx 5
+'ي'  madd    present  ['i:'] idx=[5] share_group=G
+```
+Same for an extension carrier (`ٱلرَّحْمَـٰنِ` → `م`=`m`, fatḥa & dagger-alef `ٰ` share `a:`).
+
+### Tanween (closed, continue)
+```
+# izhar  عَذَابٌ ع…     'ٌ' tanween present ['u','n']
+# ikhfaa/iqlab أَلِيمٌ ب… 'ٌ' tanween present ['u','ŋ']  tag=iqlab_tanween
+# idgham  هُدًى لِّـ…    'ً' tanween present ['a']        tag=idgham_bila_ghunnah_tanween share_group=G
+#                        + next word 'لّ' base ['ll'] share_group=G   (cross-word co-highlight)
+```
+
+### Tanween + iltiqāʾ kasra (continue) — `خَيْرٌ ٱ…`
+```
+'ٌ'  tanween  present  ['u','n'] idx=[4,5]
+''   haraka   inserted ['i']     idx=[6]  tag=iltiqaa_kasra     ← graphemeless bridge kasra
+```
+
+### Stopping — tanween dropped / madd-ʿiwaḍ
+```
+# عَظِيمٌ⏹   'ٌ' tanween dropped []            (dammatan/kasratan vanish at waqf)
+# هُدًى⏹     'ً' tanween dropped [] tag=madd_iwad
+#            'ى' madd    replaced ['a:'] tag=madd_iwad   (the long ā moves onto the alef-maksura)
+```
+
+### Hamza-waṣl pronounced (start) — `ٱلْحَمْدُ`
+```
+'ٱ'  base    present  ['ʔ'] idx=[0]
+''   haraka  inserted ['a'] idx=[1] tag=hamza_wasl_vowel   ← connecting vowel, no grapheme
+```
+
+### Allah — implicit dagger-alef — `ٱللَّهِ`
+```
+'ل'  base    present  ['lˤlˤ'] idx=[2]
+''   madd    inserted ['aˤ:']  idx=[3] tag=allah_dagger_alef
+```
+
+### Iltiqāʾ shortening (continue) — `فِى ٱل…`
+```
+'ف'  base    present   ['f'] idx=[0]
+'ِ'  haraka  shortened ['i'] idx=[1] tag=iltiqaa   ← short vowel attaches to the base
+'ى'  madd    shortened []                          ← carrier silenced
+```
+
+### Muqaṭṭaʿāt — `الٓمٓ` (2:1:1)
+```
+'ا'  base  present  ['ʔ','a','l','i','f']   ← one char, five phonemes
+'لٓ' base  present  ['l','a:']
+'مٓ' base  present  ['m̃','i:','m']
+```
+
+## Serialization
+
+```python
+cpm = result.character_phoneme_mappings()
+cpm.to_dict()                      # nested dict (named fields)
+cpm.to_list()                      # [[cell-as-list, ...] per word]
+cpm.to_json(indent=2)
+cpm.validate()                     # [] = valid
+cpm.save("out.json")
+result.save("out.json", fmt="char_phoneme")
+```
+
+Run with `result.character_phoneme_mappings(validate_result=True)` to raise on any violation.

--- a/docs/character-phoneme-mappings.md
+++ b/docs/character-phoneme-mappings.md
@@ -31,6 +31,13 @@ Inspector) derives all of that from the `tag` + the diacritic char. This keeps t
 phonemizer the single source of recitation domain knowledge and lets each renderer own its
 own script conventions (e.g. the Digital Khatt mini-meem for iqlāb).
 
+So the consumer never has to inspect the phonemes themselves, two facts that would
+otherwise require phonology are folded into the cell: a **geminated** base composes the
+canonical shaddah `ّ` into its `chars` (the consumer renders the text verbatim), and an
+**idgham-shafawi** haraka whose vowel the merged base absorbs stays `present` — carrying the
+base's `phoneme_indices` + a `share_group` — so the consumer co-lights it on the merger
+rather than greying it out.
+
 ## Output structure
 
 ```
@@ -46,7 +53,7 @@ CharPhonemeResult
 
 | Field | Meaning |
 |-------|---------|
-| `chars` | the canonical source character(s); `""` if the cell is fully implicit |
+| `chars` | the canonical source character(s) — includes a composed shaddah `ّ` on a geminated base; `""` if the cell is fully implicit |
 | `role` | `base` · `haraka` · `tanween` · `madd` |
 | `status` | `present` · `inserted` · `dropped` · `replaced` · `shortened` |
 | `phonemes` | the phoneme strings this cell sounds (`[]` if silent) |
@@ -87,6 +94,12 @@ phoneme at its index.
 ```
 'ب'  base    present  ['b'] idx=[0]
 'ِ'  haraka  present  ['i'] idx=[1]
+```
+
+### Geminate — shaddah composed into `chars` (`رَبِّ`)
+```
+'ر'   base    present  ['rˤ'] idx=[0]
+'بّ'  base    present  ['bb'] idx=[2]   ← canonical shaddah ◌ّ folded into chars
 ```
 
 ### Long vowel — haraka + carrier share the vowel (`ٱلرَّحِيمِ`, continue)

--- a/docs/tajweed-mappings.md
+++ b/docs/tajweed-mappings.md
@@ -201,6 +201,10 @@ Madd rules appear on the **vowel grapheme** that carries the lengthening:
 - Dagger alef (ٰ) / mini waw (ۥ) / mini yaa (ۦ) — split into a separate entry with the madd rule
 - Iwad (fathatan + hamza at stop) — `madd_tabii` is on the hamza entry
 
+The classified subtype lives on `MaddMapping.madd_type` and is **projected onto the cell tag**
+of the carrier grapheme in `character_phoneme_mappings()` (see `docs/character-phoneme-mappings.md`
+§ Tags). Regular ṭabīʿī carries no subtype (cell tag `null`).
+
 ## Multi-Rule Overlap
 
 A single letter can carry multiple rules from different categories simultaneously. The most common overlaps:

--- a/quranic_phonemizer/__init__.py
+++ b/quranic_phonemizer/__init__.py
@@ -22,6 +22,31 @@ from .tajweed_rule import TajweedRule, TajweedRuleTag
 from .tajweed_mapping import TajweedMapping, TajweedWordMapping, TajweedEntry
 from .letter_phoneme_mapping import FlatMappingResult
 from .char_phoneme_mapping import Cell, CharWord, CharPhonemeResult
+from .tajweed_classification import (
+    CellRole,
+    CellStatus,
+    MergerClass,
+    CrossWordMerger,
+    CROSS_WORD_MERGERS,
+    detect_cross_word_mergers,
+    BRIDGE_RULE_VALUES,
+    MERGER_ON_PREV_VALUES,
+    BOTH_SOUND_VALUES,
+    IDGHAM_SOURCE_TAG_VALUES,
+    TANWEEN_ASSIMILATES_VALUES,
+)
+from .phonemes import (
+    is_madd,
+    is_short_vowel,
+    is_geminate,
+    is_nasalised,
+    is_render_only,
+    render_only_phonemes,
+    nasalised_phonemes,
+    diacritic_chars,
+    SHORT_VOWEL_PHONEMES,
+    VOWEL_CARRIER_CHARS,
+)
 
 __all__ = [
     'Phonemizer',
@@ -47,4 +72,27 @@ __all__ = [
     'Cell',
     'CharWord',
     'CharPhonemeResult',
+    # cross-word tajweed classification + the single detector
+    'CellRole',
+    'CellStatus',
+    'MergerClass',
+    'CrossWordMerger',
+    'CROSS_WORD_MERGERS',
+    'detect_cross_word_mergers',
+    'BRIDGE_RULE_VALUES',
+    'MERGER_ON_PREV_VALUES',
+    'BOTH_SOUND_VALUES',
+    'IDGHAM_SOURCE_TAG_VALUES',
+    'TANWEEN_ASSIMILATES_VALUES',
+    # phoneme predicates + derived sets
+    'is_madd',
+    'is_short_vowel',
+    'is_geminate',
+    'is_nasalised',
+    'is_render_only',
+    'render_only_phonemes',
+    'nasalised_phonemes',
+    'diacritic_chars',
+    'SHORT_VOWEL_PHONEMES',
+    'VOWEL_CARRIER_CHARS',
 ]

--- a/quranic_phonemizer/__init__.py
+++ b/quranic_phonemizer/__init__.py
@@ -21,6 +21,7 @@ from .mapping import (
 from .tajweed_rule import TajweedRule, TajweedRuleTag
 from .tajweed_mapping import TajweedMapping, TajweedWordMapping, TajweedEntry
 from .letter_phoneme_mapping import FlatMappingResult
+from .char_phoneme_mapping import Cell, CharWord, CharPhonemeResult
 
 __all__ = [
     'Phonemizer',
@@ -43,4 +44,7 @@ __all__ = [
     'TajweedWordMapping',
     'TajweedEntry',
     'FlatMappingResult',
+    'Cell',
+    'CharWord',
+    'CharPhonemeResult',
 ]

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -97,6 +97,11 @@ MADD_RULE_TAGS = frozenset({
 # its target_rules.
 GLIDE_PHONEMES = frozenset({"j", "w"})
 
+# Istiʿlāʾ (heavy) consonant phones — for placing tafkheem on a muqaṭṭaʿ name's
+# heavy letter ( صٓ's sˤ, طٰ's tˤ, قٓ's q). The heavy long vowel after it (aˤ:)
+# already takes its madd tag; only the consonant phone is the spare slot.
+ISTILAA_CONSONANT_PHONES = frozenset({"sˤ", "dˤ", "tˤ", "ðˤ", "q", "x", "ɣ"})
+
 # Qalqala tier order for a base cell: kubra (at waqf / a final sākin) wins over
 # sughra (mid-word). Picked from the letter's OWN source rules — a qalqala letter
 # carries exactly one of these — so the cell names the precise variant instead of
@@ -338,10 +343,9 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
       - the long-vowel madd phone gets the madd rule; a name with no long vowel
         but a leen glide (عَيْن's يْ → j) puts the madd on the glide,
       - the qalqala consonant AND its render-only Q echo get qalqala_kubra,
-      - every other phone is None.
-
-    madd_tabii / qalqala / tafkheem ride through here even though the FE palette
-    leaves them uncoloured (a faithful renderer keys the colour, not this list)."""
+      - a heavy istiʿlāʾ consonant ( صٓ's sˤ, طٰ's tˤ, قٓ's q) gets tafkheem on its
+        spare slot (the heavy long vowel after it already carries its madd),
+      - every other phone is None."""
     src, tgt = _special_subword_rules(subword)
     rules = src | tgt
     madd_tag = _special_madd_tag(rules)
@@ -378,6 +382,12 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
         for k in range(1, len(lp)):
             if is_render_only(lp[k][1]) and tags[k - 1] is None:
                 tags[k - 1] = "qalqala_kubra"
+    # Tafkheem on the heavy istiʿlāʾ consonant (صٓ's sˤ / قٓ's q / طٰ's tˤ): its slot
+    # is otherwise None (the heavy vowel after it already took its madd).
+    if "tafkheem" in rules:
+        for k, (_, ph) in enumerate(lp):
+            if tags[k] is None and ph in ISTILAA_CONSONANT_PHONES:
+                tags[k] = "tafkheem"
     return tags
 
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -35,50 +35,51 @@ from .letter_phoneme_mapping import (
     should_split_extension,
     is_madd_phoneme,
     get_full_char,
-    VOWEL_LETTER_CHARS,
     TANWEEN_DIACRITICS,
     SHORT_VOWEL_PHONEMES,
 )
 from .silent import sounding_in_flat
+from .tajweed_classification import (
+    CellRole,
+    CellStatus,
+    TANWEEN_RULE_TAGS,
+    NOON_RULE_TAGS,
+    IDGHAM_SOURCE_TAG_VALUES,
+    detect_cross_word_mergers,
+)
+from .phonemes import (
+    VOWEL_CARRIER_CHARS,
+    diacritic_chars,
+    is_geminate,
+    is_render_only,
+    is_short_vowel,
+)
+
+# Shaddah (gemination mark) — composed onto a geminated base cell's chars so a
+# renderer reads it from the canonical text instead of inferring it from the
+# phoneme shape.
+SHADDA = "ّ"  # U+0651
 
 
 # =============================================================================
-# Vocabulary (canonical, JSON-friendly string constants)
+# Vocabulary — short aliases to the canonical enums (str values unchanged, so
+# the serialized cell rows are byte-identical). The diacritic name→char map,
+# the vowel-carrier set, the render-only marker set, and the tanwīn/noon rule
+# tag tuples now come from phonemes / tajweed_classification (single owners).
 # =============================================================================
 
 # Roles
-BASE = "base"        # consonant / consonantal vowel-letter / hamza / hamza-wasl
-HARAKA = "haraka"    # fatha / damma / kasra / sukun
-TANWEEN = "tanween"  # fathatan / dammatan / kasratan
-MADD = "madd"        # long-vowel carrier: ا و ي ى, mini ۥ ۦ ۧ, dagger-alef ٰ
+BASE = CellRole.BASE          # consonant / consonantal vowel-letter / hamza / hamza-wasl
+HARAKA = CellRole.HARAKA      # fatha / damma / kasra / sukun
+TANWEEN = CellRole.TANWEEN    # fathatan / dammatan / kasratan
+MADD = CellRole.MADD          # long-vowel carrier: ا و ي ى, mini ۥ ۦ ۧ, dagger-alef ٰ
 
 # Statuses
-PRESENT = "present"      # explicit, sounded
-INSERTED = "inserted"    # implicit, no source char
-DROPPED = "dropped"      # source char present but silent in this context
-REPLACED = "replaced"    # sound changed from the written form (madd-iwad)
-SHORTENED = "shortened"  # long vowel reduced; carrier silenced (iltiqaa)
-
-# Diacritic name -> its Unicode char (the phonemizer's canonical text).
-_DIAC_CHAR: Dict[str, str] = {
-    "FATHA": "َ", "DAMMA": "ُ", "KASRA": "ِ", "SUKUN": "ْ",
-    "FATHATAN": "ً", "DAMMATAN": "ٌ", "KASRATAN": "ٍ",
-}
-
-_HARAKA_DIACRITICS = {"FATHA", "DAMMA", "KASRA"}
-_QALQALA_PHONEMES = {"Q", "QQ"}
-# Mini-yaa-middle (U+06E7) behaves as a vowel letter (carrier i: or consonant j).
-_VOWEL_LETTERS = set(VOWEL_LETTER_CHARS) | {"ۧ"}
-
-# Source-rule -> tag priority for picking a cell's canonical case tag.
-_TANWEEN_RULE_TAGS = (
-    "iqlab_tanween", "ikhfaa_tanween",
-    "idgham_ghunnah_tanween", "idgham_bila_ghunnah_tanween",
-)
-_NOON_RULE_TAGS = (
-    "iqlab_noon", "ikhfaa_noon",
-    "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
-)
+PRESENT = CellStatus.PRESENT
+INSERTED = CellStatus.INSERTED
+DROPPED = CellStatus.DROPPED
+REPLACED = CellStatus.REPLACED
+SHORTENED = CellStatus.SHORTENED
 
 
 # =============================================================================
@@ -103,6 +104,10 @@ class Cell:
     source_letter_indices: List[int] = field(default_factory=list)
 
     def to_list(self) -> list:
+        """Full 9-field dump (incl. ``phonemes`` + ``source_letter_indices``). This
+        is the phonemizer's own serialization — NOT the 7-slot Timestamps shard
+        row, which a downstream consumer (the SDK) projects in a different field
+        order; do not conflate the two positionally."""
         return [
             self.chars, self.role, self.status,
             list(self.phonemes), list(self.phoneme_indices),
@@ -230,8 +235,8 @@ def _word_cells(word: WordMapping) -> List[Cell]:
             cons_pairs, mod_pairs = lp, []
 
         # Qalqala echo always rides the base cell.
-        q_pairs = [p for p in mod_pairs if p[1] in _QALQALA_PHONEMES]
-        mod_pairs = [p for p in mod_pairs if p[1] not in _QALQALA_PHONEMES]
+        q_pairs = [p for p in mod_pairs if is_render_only(p[1])]
+        mod_pairs = [p for p in mod_pairs if not is_render_only(p[1])]
 
         # Extension split (dagger-alef / mini-waw / mini-yaa carrying a long vowel
         # on the SAME letter): the madd phoneme moves to its own MADD cell.
@@ -267,14 +272,19 @@ def _word_cells(word: WordMapping) -> List[Cell]:
 
         # ---- emit the letter-sound cell (BASE or MADD) ----------------------
         base_is_vowel_carrier = (
-            diac is None and not lm.has_shaddah and lm.char in _VOWEL_LETTERS
+            diac is None and not lm.has_shaddah and lm.char in VOWEL_CARRIER_CHARS
             and all(is_madd_phoneme(p[1]) for p in base_pairs) and base_pairs
         )
         base_role = MADD if base_is_vowel_carrier else BASE
         base_tag = None
         if base_role == BASE:
-            base_tag = (_pick_tag(rules, _NOON_RULE_TAGS)
+            base_tag = (_pick_tag(rules, NOON_RULE_TAGS)
                         or ("qalqala" if q_pairs else None))
+        # Compose the canonical shaddah onto a geminated base (the aligner's bare
+        # letter char carries none) so a renderer reads the geminate from chars
+        # rather than re-deriving it from the phoneme shape.
+        if base_pairs and is_geminate(base_pairs[0][1]) and SHADDA not in base_chars:
+            base_chars = base_chars + SHADDA
         cells.append(Cell(
             chars=base_chars, role=base_role,
             status=PRESENT if base_pairs else DROPPED,
@@ -320,7 +330,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         if diac is None:
             continue
 
-        diac_char = _DIAC_CHAR.get(diac, "")
+        diac_char = diacritic_chars().get(diac, "")
         is_tanween = diac in TANWEEN_DIACRITICS
 
         # madd-iwad: tanween at stop where a madd (a:) is produced and the next
@@ -348,7 +358,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
             mod_pairs = mod_pairs[:-1]
 
         if is_tanween:
-            tan_tag = _pick_tag(rules, _TANWEEN_RULE_TAGS)
+            tan_tag = _pick_tag(rules, TANWEEN_RULE_TAGS)
             status = PRESENT
             if word.is_stopping and not mod_pairs:
                 status = DROPPED  # dammatan/kasratan dropped at waqf
@@ -398,7 +408,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         # haraka with no own phoneme: absorbed by the following vowel letter.
         nxt = li + 1
         nxt_pairs = pairs[nxt] if nxt < n_letters else []
-        if nxt_pairs and word.letter_mappings[nxt].char in _VOWEL_LETTERS:
+        if nxt_pairs and word.letter_mappings[nxt].char in VOWEL_CARRIER_CHARS:
             nidx, nph = nxt_pairs[0]
             if sounding_in_flat(word, nxt) and is_madd_phoneme(nph):
                 # long vowel: haraka + carrier share the long-vowel index
@@ -450,74 +460,60 @@ def _assign_intra_word_share_groups(cells: List[Cell], start_gid: int) -> int:
     return gid
 
 
-# Tagged cross-word idgham sources — the cell that carries the rule tag in the
-# CURRENT word. Tanwīn idgham tags a (present) TANWEEN cell; noon idgham tags the
-# (silent, dropped) NOON base. Both should share a co-light group with the
-# receiving word's first sounding base. (ikhfaa / iqlab are cross-word but do NOT
-# fully merge, so they are excluded.)
-_IDGHAM_SOURCE_TAGS = (
-    "idgham_ghunnah_tanween", "idgham_bila_ghunnah_tanween",
-    "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
-)
-
-# Cross-word idgham where a CONSONANT at the prev word's tail merges into the
-# next word's first consonant but carries NO tag on its cell — only idgham_shafawi
-# (م|مّ): its merger phoneme (m̃) lands on the prev word's tail, so the prev word's
-# last sounding base carries it while the receiving word's first base carries only
-# the following vowel. (Noon idgham is tag-detected above; its source base is
-# silent and the merger lands on the receiving word's head.)
-_CROSS_WORD_BASE_MERGE_RULES = frozenset({"idgham_shafawi"})
-
-
-def _is_cross_word_base_merge(prev_wm: WordMapping, curr_wm: WordMapping) -> bool:
-    """True if the word boundary is a consonant idgham whose two base graphemes
-    should co-light. Asks the phonemizer's tajweed rules where the merge fires
-    (source on the prev word's tail, target on the curr word's head) — mirrors the
-    cross-word bridge detector so the two stay in lockstep."""
-    if not prev_wm.letter_mappings or not curr_wm.letter_mappings:
-        return False
-    curr_targets = {
-        t.rule.value for t in curr_wm.letter_mappings[0].tajweed_rules if not t.is_source
-    }
-    for e in reversed(prev_wm.letter_mappings):
-        srcs = {t.rule.value for t in e.tajweed_rules if t.is_source}
-        if (srcs & curr_targets) & _CROSS_WORD_BASE_MERGE_RULES:
-            return True
-    return False
-
-
-def _link_cross_word(words: List[CharWord], wmaps: List[WordMapping], start_gid: int) -> int:
+def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start_gid: int) -> int:
     """Co-highlight cross-word idgham mergers: the two graphemes that voice as one
-    sound share a group, so the consumer lights both through the merger. Two shapes:
+    sound share a group, so the consumer lights both through the merger.
 
-      - tanwīn idgham — the tanwīn cell of word N and the first sounding cell of
-        word N+1 (the merger lands on N+1's head).
-      - consonant idgham (idgham shafawi م|مّ) — word N's last sounding BASE and
+    Boundaries come from the single ``detect_cross_word_mergers`` (the same detector
+    the SDK shard bridge tagger uses). Co-lighting is scoped — as before — to the
+    tagged noon/tanwīn idghams and the both-sound shafawi merge:
+
+      - tanwīn / noon idgham (``side == "curr"``, tagged) — the tagged cell of word
+        N and the first sounding base of word N+1 (the merger lands on N+1's head).
+      - consonant idgham shafawi (``both_sound``) — word N's last sounding BASE and
         word N+1's first sounding BASE (the merger m̃ lands on N's tail; N+1's base
-        carries only the following vowel)."""
+        carries only the following vowel).
+
+    (mutamathilayn / mutaqaribayn / mutajanisayn are bridges but not cell co-light
+    sources, matching the historical scope.)"""
     gid = start_gid
-    for wi in range(len(words) - 1):
-        cur, nxt = words[wi], words[wi + 1]
+    for m in detect_cross_word_mergers(mapping):
+        cur, nxt = words[m.prev_word_index], words[m.curr_word_index]
         recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
         if recv is None:
             continue
-        # Tagged idgham → the source is the tagged cell on the current word: a
-        # tanwīn cell (idgham tanween) or the silent noon base (idgham noon).
-        source = next((c for c in cur.cells if c.tag in _IDGHAM_SOURCE_TAGS), None)
-        # Untagged consonant idgham (shafawi) → the source is the current word's
-        # last sounding base (it carries the merger phoneme; the receiver carries
-        # only the following vowel).
-        if source is None and _is_cross_word_base_merge(wmaps[wi], wmaps[wi + 1]):
+        if m.both_sound:
             source = next((c for c in reversed(cur.cells)
                            if c.role == BASE and c.phoneme_indices), None)
+        elif m.rule in IDGHAM_SOURCE_TAG_VALUES:
+            source = next((c for c in cur.cells if c.tag in IDGHAM_SOURCE_TAG_VALUES), None)
+        else:
+            continue
         if source is None:
             continue
         if source.share_group is None and recv.share_group is None:
-            source.share_group = recv.share_group = gid
+            g = gid
             gid += 1
         else:
             g = source.share_group if source.share_group is not None else recv.share_group
-            source.share_group = recv.share_group = g
+        source.share_group = recv.share_group = g
+        # Absorbed-vowel co-light: when the receiving base sounds a short vowel
+        # (idgham shafawi — the consonant merged, so the base carries only the
+        # following vowel), its dropped haraka on the same letter sounds that
+        # vowel. Point the haraka at the vowel + join the merger group so a
+        # renderer co-lights it instead of greying it (no phoneme inference).
+        if recv.phonemes and is_short_vowel(recv.phonemes[0]):
+            absorbed = next(
+                (c for c in nxt.cells
+                 if c.role == HARAKA and not c.phoneme_indices
+                 and c.source_letter_index == recv.source_letter_index),
+                None,
+            )
+            if absorbed is not None:
+                absorbed.phoneme_indices = list(recv.phoneme_indices)
+                absorbed.phonemes = list(recv.phonemes)
+                absorbed.status = PRESENT
+                absorbed.share_group = g
     return gid
 
 
@@ -531,7 +527,7 @@ def build_char_phoneme_mapping(mapping: PhonemizationMapping) -> List[CharWord]:
             location=wm.location, text=wm.text,
             is_starting=wm.is_starting, is_stopping=wm.is_stopping, cells=cells,
         ))
-    gid = _link_cross_word(words, mapping.words, gid)
+    gid = _link_cross_word(words, mapping, gid)
     return words
 
 
@@ -567,7 +563,7 @@ def validate(words: List[CharWord], mapping: PhonemizationMapping) -> List[str]:
         # (3) char completeness: each letter's diacritic char appears in a cell
         for li, lm in enumerate(wm.letter_mappings):
             if lm.diacritic and not wm.is_special_word:
-                dc = _DIAC_CHAR.get(lm.diacritic, "")
+                dc = diacritic_chars().get(lm.diacritic, "")
                 anchored = [c for c in cw.cells if c.source_letter_index == li]
                 if dc and not any(dc in c.chars for c in anchored):
                     violations.append(

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -871,16 +871,16 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
     Boundaries come from the single ``detect_cross_word_mergers`` (the same detector
     the SDK shard bridge tagger uses). Two outcomes per merger:
 
-      - **co-light** (the tagged noon/tanwīn idghams + the both-sound shafawi merge):
-        source and receiver share a group, so the consumer lights both through the
-        merger and un-greys the silent source.
-      - **target-tag only** (mutaqāribayn / mutajānisayn kāmil): the receiver carries
-        the source's idgham rule as a SECONDARY tag — so it underlines + names the rule
-        (stacking above its own base rule) — but there is NO share group, so the source
-        stays silent/greyed (no co-light), per the desired distinction.
+      - **co-light** (the tagged noon/tanwīn idghams + the both-sound shafawi merge +
+        mutamāthilayn): source and receiver share a group, so the consumer lights both
+        through the merger and un-greys the silent source.
+      - **silent source** (mutaqāribayn / mutajānisayn kāmil): NO share group, so the
+        source stays silent/greyed (no co-light).
 
-    mutāmathilayn is co-light; mutaqāribayn / mutajānisayn are target-tag only.
-    (Within-word mutajānisayn nāqiṣ is handled by ``_tag_within_word_naqis``.)"""
+    Independently, EVERY consonant idgham (mutamāthilayn / mutaqāribayn / mutajānisayn)
+    also puts its rule on the receiver as a SECONDARY tag, so the target underlines +
+    names the rule uniformly. mutamāthilayn is co-light AND secondary-tagged.
+    (Within-word consonant idghams are handled by ``_tag_within_word_idgham``.)"""
     gid = start_gid
     for m in detect_cross_word_mergers(mapping):
         cur, nxt = words[m.prev_word_index], words[m.curr_word_index]
@@ -906,12 +906,17 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
             continue
         if recv is None or source is None:
             continue
+        # Every consonant idgham (mutamāthilayn / mutaqāribayn / mutajānisayn) puts its
+        # rule on the receiver as a SECONDARY tag, so the target underlines + names the
+        # rule (a `merge`-layer secondary, above its own base rule) uniformly — whether
+        # or not it also co-lights. The noon/tanwīn/shafawi receivers underline through
+        # their share group instead, so they get no secondary.
+        if (m.rule in CONSONANT_IDGHAM_RULE_TAGS and source.tag
+                and source.tag != recv.tag and source.tag not in recv.secondary_tags):
+            recv.secondary_tags.append(source.tag)
         if not co_light:
-            # Target-tag only: the receiver underlines + names the rule (a `merge`-layer
-            # secondary, stacking above its own base rule), without sharing a group.
-            if (source.tag and source.tag != recv.tag
-                    and source.tag not in recv.secondary_tags):
-                recv.secondary_tags.append(source.tag)
+            # mutaqāribayn / mutajānisayn kāmil: no share group, so the source stays
+            # silent/greyed (no co-light) while the target underlines via the secondary.
             continue
         if source.share_group is None and recv.share_group is None:
             g = gid
@@ -943,17 +948,17 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
     return gid
 
 
-def _tag_within_word_naqis(cells: List[Cell]) -> None:
-    """Tag the TARGET of a within-word mutajānisayn nāqiṣ (طت: بَسَطتَ) so it underlines
-    + names the rule alongside its sounding source. Both letters sound (nāqiṣ), so this
-    is a pure secondary-tag on the next base — no merger/share-group involved."""
-    NAQIS = "idgham_mutajanisayn_naqis"
+def _tag_within_word_idgham(cells: List[Cell]) -> None:
+    """Tag the TARGET of a within-word consonant idgham so it underlines + names the rule
+    alongside its source — a pure secondary-tag on the next base, no merger/share-group.
+    Covers mutaqāribayn (قك: نَخْلُقكُّم, source silent) and mutajānisayn nāqiṣ (طت: بَسَطتَ,
+    both letters sound); cross-word boundaries are handled by ``_link_cross_word``."""
     for i, c in enumerate(cells):
-        if c.tag != NAQIS:
+        if c.tag not in CONSONANT_IDGHAM_RULE_TAGS:
             continue
         tgt = next((t for t in cells[i + 1:] if t.role == BASE), None)
-        if tgt and tgt.tag != NAQIS and NAQIS not in tgt.secondary_tags:
-            tgt.secondary_tags.append(NAQIS)
+        if tgt and tgt.tag != c.tag and c.tag not in tgt.secondary_tags:
+            tgt.secondary_tags.append(c.tag)
 
 
 def build_char_phoneme_mapping(mapping: PhonemizationMapping) -> List[CharWord]:
@@ -961,7 +966,7 @@ def build_char_phoneme_mapping(mapping: PhonemizationMapping) -> List[CharWord]:
     gid = 0
     for wm in mapping.words:
         cells = (_special_word_cells(wm) if wm.is_special_word else _word_cells(wm))
-        _tag_within_word_naqis(cells)
+        _tag_within_word_idgham(cells)
         gid = _assign_intra_word_share_groups(cells, gid)
         words.append(CharWord(
             location=wm.location, text=wm.text,

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -47,6 +47,7 @@ from .tajweed_classification import (
     TANWEEN_RULE_TAGS,
     NOON_RULE_TAGS,
     GHUNNAH_BASE_TAGS,
+    CONSONANT_IDGHAM_RULE_TAGS,
     IDGHAM_SOURCE_TAG_VALUES,
     detect_cross_word_mergers,
 )
@@ -457,6 +458,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                 chars=full, role=MADD, status=REPLACED,
                 phonemes=[ph], phoneme_indices=[idx], tag="madd_iwad",
                 source_letter_index=li, source_letter_indices=[li],
+                secondary_tags=["tafkheem"] if ph in HEAVY_VOWEL_PHONEMES else [],
             ))
             continue
         if li in force_dropped:
@@ -565,6 +567,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                         or _pick_tag(rules, GHUNNAH_BASE_TAGS)
                         or (madd_types.get(base_pairs[0][0]) if base_pairs else None)
                         or (_pick_tag(rules, QALQALA_RULE_ORDER) if q_pairs else None)
+                        or _pick_tag(rules, CONSONANT_IDGHAM_RULE_TAGS)
                         or ("tafkheem" if "tafkheem" in rules else None))
         elif waqf_vowel_carrier:
             # ʿāriḍ-li-s-sukūn at the stop. A plain ṭabīʿī madd (now mapped to
@@ -672,9 +675,11 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                 and is_madd_phoneme(mod_pairs[-1][1])):
             madd_iwad = mod_pairs[-1]
             mod_pairs = [p for p in mod_pairs if p != madd_iwad]
+            # The dropped fatḥatan carries NO underline — its compensating madd rides
+            # the ʾalif (the carrier cells below), which holds the madd + tafkhīm bars.
             cells.append(Cell(
                 chars=diac_char, role=TANWEEN, status=DROPPED,
-                phonemes=[], phoneme_indices=[], tag="madd_iwad",
+                phonemes=[], phoneme_indices=[], tag=None,
                 source_letter_index=li, source_letter_indices=[li],
             ))
             if (li + 1 < n_letters
@@ -687,6 +692,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                     phonemes=[madd_iwad[1]], phoneme_indices=[madd_iwad[0]],
                     tag="madd_iwad",
                     source_letter_index=li, source_letter_indices=[li],
+                    secondary_tags=["tafkheem"] if madd_iwad[1] in HEAVY_VOWEL_PHONEMES else [],
                 ))
             continue
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -784,11 +784,14 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
         else:
             g = source.share_group if source.share_group is not None else recv.share_group
         source.share_group = recv.share_group = g
-        # Absorbed-vowel co-light: when the receiving base sounds a short vowel
-        # (idgham shafawi — the consonant merged, so the base carries only the
-        # following vowel), its dropped haraka on the same letter sounds that
-        # vowel. Point the haraka at the vowel + join the merger group so a
-        # renderer co-lights it instead of greying it (no phoneme inference).
+        # Idgham shafawi convergence: the receiving meem's BASE sounds the following
+        # short vowel (the consonant merged into the source meem's m̃, which carries
+        # the whole geminated nasal). Move that vowel onto the meem's own haraka — its
+        # OWN interval, NOT the merger group — and strip it off the base, so the base
+        # owns no phoneme and co-lights purely through the nasal/share union, exactly
+        # like an idgham-ghunnah/noon receiver. This keeps the vowel off the base
+        # (so it aligns under its haraka) and out of the union (so looping the haraka
+        # no longer intersects either meem's cell span).
         if recv.phonemes and is_short_vowel(recv.phonemes[0]):
             absorbed = next(
                 (c for c in nxt.cells
@@ -800,7 +803,8 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
                 absorbed.phoneme_indices = list(recv.phoneme_indices)
                 absorbed.phonemes = list(recv.phonemes)
                 absorbed.status = PRESENT
-                absorbed.share_group = g
+                recv.phoneme_indices = []
+                recv.phonemes = []
     return gid
 
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -766,17 +766,21 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
     gid = start_gid
     for m in detect_cross_word_mergers(mapping):
         cur, nxt = words[m.prev_word_index], words[m.curr_word_index]
-        recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
-        if recv is None:
-            continue
         if m.both_sound:
+            # Idgham shafawi: the receiver is the next word's FIRST base (the meem),
+            # which may own NO phoneme — the merged consonant lives on the source
+            # meem, and a following long vowel sits on its own alef/madd (مَّا → the
+            # aː is on the alef). Don't require phoneme_indices, else the meem is
+            # never linked and greys out.
+            recv = next((c for c in nxt.cells if c.role == BASE), None)
             source = next((c for c in reversed(cur.cells)
                            if c.role == BASE and c.phoneme_indices), None)
         elif m.rule in IDGHAM_SOURCE_TAG_VALUES:
+            recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
             source = next((c for c in cur.cells if c.tag in IDGHAM_SOURCE_TAG_VALUES), None)
         else:
             continue
-        if source is None:
+        if recv is None or source is None:
             continue
         if source.share_group is None and recv.share_group is None:
             g = gid

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -38,7 +38,7 @@ from .letter_phoneme_mapping import (
     TANWEEN_DIACRITICS,
     SHORT_VOWEL_PHONEMES,
 )
-from .silent import sounding_in_flat
+from .silent import sounding_in_flat, _is_carrier_waw
 from .specials import get_tajweed_mapping
 from .tajweed_classification import (
     CellRole,
@@ -412,6 +412,17 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         # Extension split (dagger-alef / mini-waw / mini-yaa carrying a long vowel
         # on the SAME letter): the madd phoneme moves to its own MADD cell.
         split = should_split_extension(lm, word)
+        # A silent carrier-waw seat (صَلَوٰة, زَكَوٰة): should_split_extension suppresses
+        # the split as a vowel-letter-all-madd carrier, but the shard tokenizes the
+        # dagger-alef as its own grapheme and flags the waw silent (silent.py). Force
+        # the same split at the cell tier so the waw greys and the dagger carries the
+        # madd, instead of merging into one وٰ carrier cell.
+        if not split and _is_carrier_waw(lm):
+            dagger = "".join(ext.char for ext in lm.extensions
+                             if ext.name == "DAGGER_ALEF" and ext.char)
+            madd_ph = next((p for p in reversed(lm.phonemes) if is_madd_phoneme(p)), None)
+            if dagger and madd_ph is not None:
+                split = (dagger, madd_ph)
         madd_pair = None
         madd_chars = None
         if split:
@@ -689,7 +700,29 @@ def _word_cells(word: WordMapping) -> List[Cell]:
             source_letter_index=li, source_letter_indices=[li],
         ))
 
+    _reorder_dropped_silah(cells)
     return cells
+
+
+def _reorder_dropped_silah(cells: List[Cell]) -> None:
+    """Move a dropped pronoun-haa ṣilah cell to just after the haa's own haraka.
+
+    The ṣilah glyph is emitted right after its base (before the haa's ḍamma/kasra),
+    but orthographically the haraka sits on the haa and precedes the mini-waw/yaa.
+    At waqf the pair is silent (no shared vowel group to re-sort downstream), so the
+    raw cell order is what renders — reorder to ``[base, haraka, ṣilah]``. The
+    dropped ṣilah is the only MADD cell that is ``DROPPED`` yet keeps its glyph."""
+    for i, c in enumerate(cells):
+        if not (c.role == MADD and c.status == DROPPED and c.chars):
+            continue
+        silah = cells.pop(i)
+        for j in range(i, len(cells)):
+            if (cells[j].role == HARAKA
+                    and cells[j].source_letter_index == silah.source_letter_index):
+                cells.insert(j + 1, silah)
+                return
+        cells.insert(i, silah)  # no haraka on the letter — leave as emitted
+        return
 
 
 def _assign_intra_word_share_groups(cells: List[Cell], start_gid: int) -> int:

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -103,6 +103,11 @@ GLIDE_PHONEMES = frozenset({"j", "w"})
 # already takes its madd tag; only the consonant phone is the spare slot.
 ISTILAA_CONSONANT_PHONES = frozenset({"sˤ", "dˤ", "tˤ", "ðˤ", "q", "x", "ɣ"})
 
+# Every heavy consonant phone that carries tafkheem inside a muqaṭṭaʿ name: the
+# istiʿlāʾ set plus the heavy rāʾ (الٓر / الٓمٓر's ر → rˤ, which is mufakhkham but
+# not istiʿlāʾ).
+MUQ_TAFKHEEM_CONSONANT_PHONES = ISTILAA_CONSONANT_PHONES | {"rˤ", "rˤ:"}
+
 # Qalqala tier order for a base cell: kubra (at waqf / a final sākin) wins over
 # sughra (mid-word). Picked from the letter's OWN source rules — a qalqala letter
 # carries exactly one of these — so the cell names the precise variant instead of
@@ -346,7 +351,7 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
       - the qalqala consonant carries qalqala_kubra (the render-only Q echo is NOT
         an indexable phone, so a downstream shard drops it — the consonant is the
         only slot the rule can ride; a renderer moves the underline to the echo),
-      - a heavy istiʿlāʾ consonant ( صٓ's sˤ, طٰ's tˤ, قٓ's q) gets tafkheem on its
+      - a heavy consonant ( صٓ's sˤ, طٰ's tˤ, قٓ's q, الٓر's rˤ) gets tafkheem on its
         spare slot (the heavy long vowel after it already carries its madd),
       - every other phone is None."""
     src, tgt = _special_subword_rules(subword)
@@ -387,11 +392,11 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
         for k in range(1, len(lp)):
             if is_render_only(lp[k][1]) and tags[k - 1] is None:
                 tags[k - 1] = "qalqala_kubra"
-    # Tafkheem on the heavy istiʿlāʾ consonant (صٓ's sˤ / قٓ's q / طٰ's tˤ): its slot
+    # Tafkheem on the heavy consonant (صٓ's sˤ / قٓ's q / طٰ's tˤ / الٓر's rˤ): its slot
     # is otherwise None (the heavy vowel after it already took its madd).
     if "tafkheem" in rules:
         for k, (_, ph) in enumerate(lp):
-            if tags[k] is None and ph in ISTILAA_CONSONANT_PHONES:
+            if tags[k] is None and ph in MUQ_TAFKHEEM_CONSONANT_PHONES:
                 tags[k] = "tafkheem"
     return tags
 
@@ -399,14 +404,17 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
 def _special_word_cells(word: WordMapping) -> List[Cell]:
     """Muqaṭṭaʿāt / hardcoded words: one cell per sounding letter. A spelled-out name
     renders as its single bare-letter grapheme (لام is one ل glyph, not ل+phantom-alef),
-    so each letter stays ONE cell. The cell's headline ``tag`` is the name's LETTER-tier
-    madd (madd_lazim نُوٓنْ / لَآم, madd_tabii هَا, عَيْن's leen → madd_lazim); the new
-    ``phoneme_rule_tags`` then carries the finer per-phone rules the bare-letter cell
-    would otherwise smear — the merged nasal's idgham_shafawi, the ikhfaa nasal's
-    ikhfaa_noon, the long vowel / leen glide's madd, the dāl/Q qalqala. Both come from
-    the grapheme-aligned YAML ``tajweed_mapping`` (the same source ``tajweed_mappings()``
-    trusts). A name with neither madd nor nasal (the أَلِفْ head of الٓم) stays an
-    untagged BASE cell."""
+    so each letter stays ONE cell. The cell's headline ``tag`` is the name's 6-count
+    LETTER-tier madd (madd_lazim نُوٓنْ / لَآم, عَيْن's leen → madd_lazim); a 2-count
+    madd_tabii name (طَا / هَا / يَا / ḥā / rā) stays a BASE cell so the bare consonant
+    glyph isn't barred, its madd living on the long-vowel phone in ``phoneme_rule_tags``.
+    That same per-phone list carries the finer rules the bare-letter cell would otherwise
+    smear — the merged nasal's idgham_shafawi, the ikhfaa nasal's ikhfaa_noon, the long
+    vowel / leen glide's madd, the heavy consonant's tafkheem, the dāl/Q qalqala. A heavy
+    name (ص ق ط / heavy rāʾ) also carries ``secondary_tags=["tafkheem"]`` so its glyph
+    underlines as mufakhkham. Both come from the grapheme-aligned YAML ``tajweed_mapping``
+    (the same source ``tajweed_mappings()`` trusts). A name with neither madd nor nasal
+    (the أَلِفْ head of الٓم) stays an untagged BASE cell."""
     cells: List[Cell] = []
     pairs = _letter_pairs(word)
     subwords = get_tajweed_mapping(word.location) or []
@@ -421,14 +429,22 @@ def _special_word_cells(word: WordMapping) -> List[Cell]:
         rule_tags = _special_phoneme_tags(subword, lp)
         src, tgt = _special_subword_rules(subword)
         madd_tag = _special_madd_tag(src | tgt)
-        # A named madd (every letter but the bare أَلِفْ head) underlines + groups
-        # as MADD; only a rule-free head stays a plain BASE cell.
-        role = MADD if madd_tag else BASE
+        # The cell's headline madd underlines the whole letter only for a 6-count
+        # madd_lazim (لَآم / نُوٓنْ / عَيْن's leen); a 2-count madd_tabii letter (ṭā / hā /
+        # yā / ḥā / rā) keeps madd_tabii on its long-vowel phone via phoneme_rule_tags
+        # and renders as a BASE cell, so the consonant glyph itself stays unbarred.
+        cell_tag = madd_tag if madd_tag != "madd_tabii" else None
+        role = MADD if cell_tag else BASE
+        # A heavy letter (istiʿlāʾ ص ق ط or the heavy rāʾ) is mufakhkham as a whole —
+        # the letter glyph carries a tafkheem bar (the per-phone tafkheem above is the
+        # phoneme-row twin).
+        heavy = any(ph in MUQ_TAFKHEEM_CONSONANT_PHONES for _, ph in lp)
         cells.append(Cell(
             chars=get_full_char(lm), role=role, status=PRESENT,
             phonemes=[p for _, p in lp], phoneme_indices=[i for i, _ in lp],
-            tag=madd_tag, source_letter_index=li, source_letter_indices=[li],
+            tag=cell_tag, source_letter_index=li, source_letter_indices=[li],
             phoneme_rule_tags=rule_tags,
+            secondary_tags=["tafkheem"] if heavy else [],
         ))
     return cells
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -39,6 +39,7 @@ from .letter_phoneme_mapping import (
     SHORT_VOWEL_PHONEMES,
 )
 from .silent import sounding_in_flat
+from .specials import get_tajweed_mapping
 from .tajweed_classification import (
     CellRole,
     CellStatus,
@@ -61,6 +62,34 @@ from .phonemes import (
 # renderer reads it from the canonical text instead of inferring it from the
 # phoneme shape.
 SHADDA = "ّ"  # U+0651
+
+# Pronoun-haa ṣilah extensions (mini-waw ۥ / mini-yaa ۦ). At wasl these carry a
+# long vowel and split into their own madd cell (should_split_extension); at waqf
+# the ṣilah drops, so the extension produces no phoneme and would otherwise stay
+# glued onto the haa base char — B2 splits it into a silent dropped madd cell.
+SILAH_EXTENSION_NAMES = frozenset({"MINI_WAW", "MINI_YA_END"})
+
+# Iqlab tanwīn split — the doubled tanwīn sounds [short-vowel, nasal mīm]. B1
+# decomposes it into a plain haraka (the short vowel) + a mini-meem cell (the
+# nasal), the meem glyph mirroring the renderer's IQLAB_FORM: a small high meem
+# (U+06E2) above a fatḥa/ḍamma, a small low meem (U+06ED) below a kasra.
+MEEM_HI = "ۢ"  # U+06E2 ARABIC SMALL HIGH MEEM ISOLATED FORM
+MEEM_LO = "ۭ"  # U+06ED ARABIC SMALL LOW MEEM
+IQLAB_MINI_MEEM = {"FATHATAN": MEEM_HI, "DAMMATAN": MEEM_HI, "KASRATAN": MEEM_LO}
+# The bare short-vowel mark a doubled tanwīn decomposes to (fatḥatan→fatḥa, …).
+IQLAB_SHORT_VOWEL = {"FATHATAN": "َ", "DAMMATAN": "ُ", "KASRATAN": "ِ"}
+
+# Madd rule tag values (the muqaṭṭaʿāt YAML uses these enum strings verbatim as
+# source_rules; the FE colours madd_lazim/wajib/jaiz/arid/leen, ṭabīʿī uncoloured).
+MADD_RULE_TAGS = frozenset({
+    "madd_tabii", "madd_lazim", "madd_arid_lissukun", "madd_leen",
+    "madd_wajib_muttasil", "madd_jaiz_munfasil",
+})
+# Base-cell rule tags a muqaṭṭaʿ letter can carry (noon/ghunnah/idgham/qalqala) —
+# the order is the colour priority when a subword names several.
+SPECIAL_BASE_TAGS = (
+    NOON_RULE_TAGS + GHUNNAH_BASE_TAGS + tuple(IDGHAM_SOURCE_TAG_VALUES) + ("qalqala_kubra",)
+)
 
 
 # =============================================================================
@@ -148,6 +177,23 @@ def _source_rules(lm: LetterMapping) -> set:
     return {t.rule.value for t in lm.tajweed_rules if t.is_source}
 
 
+def _dropped_silah_chars(lm: LetterMapping, word: WordMapping) -> Optional[str]:
+    """The mini-waw/mini-yaa ṣilah glyph on a pronoun-haa whose ṣilah dropped at
+    waqf (so ``should_split_extension`` finds no madd phoneme to split out). Returns
+    the extension chars when the word is stopping and the ṣilah produced no madd
+    phoneme on this letter, else None — the wasl case keeps going through the normal
+    extension split."""
+    if not word.is_stopping:
+        return None
+    if any(is_madd_phoneme(ph) for ph in lm.phonemes):
+        return None
+    silah = [ext for ext in lm.extensions
+             if ext.char and ext.name in SILAH_EXTENSION_NAMES]
+    if not silah:
+        return None
+    return "".join(ext.char for ext in silah)
+
+
 def _pick_tag(rules: set, order: Tuple[str, ...]) -> Optional[str]:
     for r in order:
         if r in rules:
@@ -189,18 +235,52 @@ def _madd_type_indices(word: WordMapping) -> Dict[int, str]:
 # Builder
 # =============================================================================
 
+def _special_subword_tags(subword: dict) -> Tuple[Optional[str], Optional[str]]:
+    """(base_tag, madd_tag) for one spelled-out muqaṭṭaʿ name (a tajweed_mapping
+    subword). The madd tag colours the long-vowel carrier; the base tag carries any
+    noon/ghunnah/idgham/qalqala the name sounds (e.g. the لَآمْ idgham-shafawi, the
+    عَيْن ikhfaa-noon). qalqala_kubra is normalised to the plain ``qalqala`` the FE
+    duration logic + ``_word_cells`` use."""
+    rules: List[str] = []
+    for e in subword.get("entries", []):
+        rules.extend(e.get("source_rules", []))
+    madd_tag = next((r for r in rules if r in MADD_RULE_TAGS), None)
+    base_tag = _pick_tag(set(rules), SPECIAL_BASE_TAGS)
+    if base_tag == "qalqala_kubra":
+        base_tag = "qalqala"
+    return base_tag, madd_tag
+
+
 def _special_word_cells(word: WordMapping) -> List[Cell]:
-    """Muqaṭṭaʿāt / hardcoded words: one BASE cell per sounding letter."""
+    """Muqaṭṭaʿāt / hardcoded words: one cell per sounding letter. A spelled-out name
+    renders as its single bare-letter grapheme (لام is one ل glyph, not ل+phantom-alef),
+    so each letter stays ONE cell — but it now carries a tajweed ``tag`` so the FE
+    underlines it. Tags come from the grapheme-aligned YAML ``tajweed_mapping`` (the
+    same source ``tajweed_mappings()`` trusts): a name with a long vowel becomes a
+    MADD cell tagged with its madd subtype (madd_lazim نُوٓنْ, madd_tabii هَا, …); a
+    pure-consonant name (the leen عَيْن, the closing رَا of الٓر) stays a BASE cell
+    carrying any noon/ghunnah/idgham/qalqala the name sounds."""
     cells: List[Cell] = []
     pairs = _letter_pairs(word)
+    subwords = get_tajweed_mapping(word.location) or []
+    sub_i = 0
     for li, lm in enumerate(word.letter_mappings):
         lp = pairs[li]
         if not lp:
             continue  # inert (e.g. trailing stop-sign entry " ۚ")
+        subword = subwords[sub_i] if sub_i < len(subwords) else {}
+        sub_i += 1
+        base_tag, madd_tag = _special_subword_tags(subword)
+
+        has_madd = any(is_madd_phoneme(ph) for _, ph in lp)
+        role = MADD if has_madd else BASE
+        # A madd name shows its madd colour (the headline 6-count for lazim); a
+        # consonant-only name shows its merge/ikhfaa rule.
+        tag = madd_tag if has_madd else base_tag
         cells.append(Cell(
-            chars=get_full_char(lm), role=BASE, status=PRESENT,
+            chars=get_full_char(lm), role=role, status=PRESENT,
             phonemes=[p for _, p in lp], phoneme_indices=[i for i, _ in lp],
-            source_letter_index=li, source_letter_indices=[li],
+            tag=tag, source_letter_index=li, source_letter_indices=[li],
         ))
     return cells
 
@@ -275,6 +355,16 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         else:
             base_chars = full
 
+        # Dropped pronoun-haa ṣilah at waqf: the mini-waw/yaa carried a long vowel
+        # at wasl but the ṣilah dropped at the stop, so should_split_extension found
+        # no madd phoneme and the glyph would stay glued onto the haa base. Strip it
+        # off the base and remember it — a silent dropped MADD cell is emitted below.
+        dropped_silah_chars = None
+        if not split:
+            dropped_silah_chars = _dropped_silah_chars(lm, word)
+            if dropped_silah_chars:
+                base_chars = base_chars.replace(dropped_silah_chars, "", 1)
+
         base_pairs = cons_pairs + q_pairs
 
         # Implicit Allah dagger-alef: a madd in mod with no grapheme.
@@ -291,13 +381,29 @@ def _word_cells(word: WordMapping) -> List[Cell]:
             diac is None and not lm.has_shaddah and lm.char in VOWEL_CARRIER_CHARS
             and all(is_madd_phoneme(p[1]) for p in base_pairs) and base_pairs
         )
-        base_role = MADD if base_is_vowel_carrier else BASE
+        # Waqf consonant→vowel carrier: a word-final و/ى lengthened from the
+        # preceding haraka (هُوَ / هِىَ / نِعْمَتِىَ). Its OWN written diacritic
+        # (the trailing fatḥa) is dropped at the stop, so it never qualifies as a
+        # plain vowel carrier (which requires diac is None), yet its base phoneme
+        # is the long vowel. Promote it to a madd carrier so the FE groups it with
+        # the stolen ḍamma/kasra (share_group already forms); the trailing fatḥa
+        # falls out as a separate dropped haraka cell below. Tagged ʿāriḍ-li-s-sukūn
+        # (consistent with the ʿiwaḍ-alef / Allah-dagger carriers at waqf).
+        waqf_vowel_carrier = (
+            not base_is_vowel_carrier and word.is_stopping and not split
+            and not lm.has_shaddah and lm.char in VOWEL_CARRIER_CHARS
+            and diac is not None and not mod_pairs and base_pairs
+            and all(is_madd_phoneme(p[1]) for p in base_pairs)
+        )
+        base_role = MADD if (base_is_vowel_carrier or waqf_vowel_carrier) else BASE
         base_tag = None
         if base_role == BASE:
             base_tag = (_pick_tag(rules, NOON_RULE_TAGS)
                         or _pick_tag(rules, GHUNNAH_BASE_TAGS)
                         or (madd_types.get(base_pairs[0][0]) if base_pairs else None)
                         or ("qalqala" if q_pairs else None))
+        elif waqf_vowel_carrier:
+            base_tag = madd_types.get(base_pairs[0][0], "madd_arid_lissukun")
         elif base_pairs:  # standalone long-vowel carrier (ا/آ/و/ي) — its madd type
             base_tag = madd_types.get(base_pairs[0][0])
         # Compose the canonical shaddah onto a mushaddad base (the aligner's bare
@@ -326,6 +432,18 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                 chars=madd_chars, role=MADD, status=PRESENT,
                 phonemes=[madd_pair[1]], phoneme_indices=[madd_pair[0]],
                 tag=madd_types.get(madd_pair[0]),
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+
+        # ---- dropped pronoun-haa ṣilah cell (waqf) --------------------------
+        # The ṣilah glyph keeps its own MADD cell (status=dropped, no phoneme) so
+        # the renderer shows هـ | (silent haraka + silent ṣilah) instead of gluing
+        # the mini-waw/yaa onto the haa. The dropped haraka rides it as a silent
+        # vowel group below.
+        if dropped_silah_chars:
+            cells.append(Cell(
+                chars=dropped_silah_chars, role=MADD, status=DROPPED,
+                phonemes=[], phoneme_indices=[],
                 source_letter_index=li, source_letter_indices=[li],
             ))
 
@@ -399,6 +517,27 @@ def _word_cells(word: WordMapping) -> List[Cell]:
 
         if is_tanween:
             tan_tag = _pick_tag(rules, TANWEEN_RULE_TAGS)
+
+            # iqlab tanwīn split: the doubled tanwīn sounds [short-vowel, nasal];
+            # emit the vowel as a plain (untagged) haraka and the nasal as its own
+            # mini-meem cell carrying the iqlab tag, both anchored to the base so a
+            # renderer groups them per-column [base, haraka, mini-meem].
+            if (tan_tag == "iqlab_tanween" and len(mod_pairs) == 2
+                    and diac in IQLAB_MINI_MEEM):
+                v_idx, v_ph = mod_pairs[0]
+                n_idx, n_ph = mod_pairs[1]
+                cells.append(Cell(
+                    chars=IQLAB_SHORT_VOWEL[diac], role=HARAKA, status=PRESENT,
+                    phonemes=[v_ph], phoneme_indices=[v_idx], tag=None,
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
+                cells.append(Cell(
+                    chars=IQLAB_MINI_MEEM[diac], role=TANWEEN, status=INSERTED,
+                    phonemes=[n_ph], phoneme_indices=[n_idx], tag="iqlab_tanween",
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
+                continue
+
             status = PRESENT
             if word.is_stopping and not mod_pairs:
                 status = DROPPED  # dammatan/kasratan dropped at waqf
@@ -600,12 +739,17 @@ def validate(words: List[CharWord], mapping: PhonemizationMapping) -> List[str]:
                     violations.append(
                         f"{wm.location}: phoneme index {i} shared by cells without one "
                         f"share_group (groups={groups})")
-        # (3) char completeness: each letter's diacritic char appears in a cell
+        # (3) char completeness: each letter's diacritic char appears in a cell.
+        # An iqlab tanwīn is decomposed into [short-vowel haraka, mini-meem] cells
+        # (B1), so its doubled-tanwīn glyph is intentionally absent — the
+        # iqlab_tanween-tagged mini-meem cell stands in for it.
         for li, lm in enumerate(wm.letter_mappings):
             if lm.diacritic and not wm.is_special_word:
                 dc = diacritic_chars().get(lm.diacritic, "")
                 anchored = [c for c in cw.cells if c.source_letter_index == li]
-                if dc and not any(dc in c.chars for c in anchored):
+                iqlab_split = (lm.diacritic in IQLAB_MINI_MEEM
+                               and any(c.tag == "iqlab_tanween" for c in anchored))
+                if dc and not iqlab_split and not any(dc in c.chars for c in anchored):
                     violations.append(
                         f"{wm.location}: letter {li} ({lm.char!r}) diacritic "
                         f"{lm.diacritic} has no cell")

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -59,6 +59,7 @@ from .phonemes import (
     is_render_only,
     is_short_vowel,
 )
+from .tajweed_mapping import HEAVY_VOWEL_PHONEMES
 
 # Shaddah (gemination mark) — composed onto a geminated base cell's chars so a
 # renderer reads it from the canonical text instead of inferring it from the
@@ -140,7 +141,12 @@ class Cell:
     only on muqaṭṭaʿāt letter cells, whose single bare-letter grapheme sounds out
     a multi-letter name carrying several distinct rules (the merged nasal, the
     long-vowel madd, the leen glide, the qalqala echo). When empty, a consumer
-    falls back to the cell's single ``tag``."""
+    falls back to the cell's single ``tag``.
+
+    ``secondary_tags`` holds extra rules that co-occur on this grapheme but lose
+    the single-``tag`` priority pick — in practice ``["tafkheem"]`` on a heavy
+    madd carrier or qalqala letter, where ``tag`` is the madd/qalqala rule. A
+    consumer renders them as additional badges stacked on the primary ``tag``."""
     chars: str
     role: str
     status: str
@@ -151,20 +157,21 @@ class Cell:
     source_letter_index: int = -1
     source_letter_indices: List[int] = field(default_factory=list)
     phoneme_rule_tags: List[Optional[str]] = field(default_factory=list)
+    secondary_tags: List[str] = field(default_factory=list)
 
     def to_list(self) -> list:
         """Full dump (incl. ``phonemes`` + ``source_letter_indices`` +
         ``phoneme_rule_tags``). This is the phonemizer's own serialization — NOT
         the Timestamps shard row, which a downstream consumer (the SDK) projects
         in a different field order; do not conflate the two positionally.
-        ``phoneme_rule_tags`` is appended last (additive slot) so a reader of an
-        older row tolerates its absence."""
+        ``phoneme_rule_tags`` then ``secondary_tags`` are appended last (additive
+        slots) so a reader of an older row tolerates their absence."""
         return [
             self.chars, self.role, self.status,
             list(self.phonemes), list(self.phoneme_indices),
             self.tag, self.share_group,
             self.source_letter_index, list(self.source_letter_indices),
-            list(self.phoneme_rule_tags),
+            list(self.phoneme_rule_tags), list(self.secondary_tags),
         ]
 
     def to_dict(self) -> dict:
@@ -179,6 +186,7 @@ class Cell:
             "source_letter_index": self.source_letter_index,
             "source_letter_indices": list(self.source_letter_indices),
             "phoneme_rule_tags": list(self.phoneme_rule_tags),
+            "secondary_tags": list(self.secondary_tags),
         }
 
 
@@ -562,6 +570,15 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                 and (is_geminate(base_pairs[0][1])
                      or (is_nasalised(base_pairs[0][1]) and lm.has_shaddah))):
             base_chars = base_chars + SHADDA
+        # Heaviness (tafkheem) co-occurs with a madd / qalqala that wins the single
+        # ``tag`` pick (a heavy ا carrier, a heavy قْ/طْ). Preserve it as a secondary
+        # rule so a renderer can stack the tafkheem badge on the primary one. A heavy
+        # vowel CARRIER (the full alef after a heavy consonant) carries no tafkheem on
+        # its own ``lm`` — its heaviness is the long-vowel phoneme itself — so detect
+        # it from the phoneme too, mirroring tajweed_mapping's HEAVY_VOWEL_PHONEMES.
+        base_heavy = ("tafkheem" in rules
+                      or any(p[1] in HEAVY_VOWEL_PHONEMES for p in base_pairs))
+        base_secondary = ["tafkheem"] if (base_heavy and base_tag != "tafkheem") else []
         cells.append(Cell(
             chars=base_chars, role=base_role,
             status=PRESENT if base_pairs else DROPPED,
@@ -569,16 +586,21 @@ def _word_cells(word: WordMapping) -> List[Cell]:
             phoneme_indices=[i for i, _ in base_pairs],
             tag=base_tag,
             source_letter_index=li, source_letter_indices=[li],
+            secondary_tags=base_secondary,
         ))
 
         # ---- madd extension cell --------------------------------------------
         # (dagger-alef / mini-waw / mini-yaa carrier on the same letter — its madd type)
         if split and madd_pair is not None:
+            # The split madd carrier (dagger-alef / mini-waw/yaa) inherits the
+            # letter's heaviness too (e.g. صٰ): stack tafkheem on its madd tag.
+            madd_secondary = ["tafkheem"] if "tafkheem" in rules else []
             cells.append(Cell(
                 chars=madd_chars, role=MADD, status=PRESENT,
                 phonemes=[madd_pair[1]], phoneme_indices=[madd_pair[0]],
                 tag=madd_types.get(madd_pair[0]),
                 source_letter_index=li, source_letter_indices=[li],
+                secondary_tags=madd_secondary,
             ))
 
         # ---- dropped pronoun-haa ṣilah cell (waqf) --------------------------

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -1,0 +1,627 @@
+"""
+Character-level phoneme mapping (haraka / tanween cells).
+
+Where ``letter_phoneme_mappings`` aligns one entry per *letter*, this maps one
+**cell per written character** — base letter, every haraka / tanween, the long-vowel
+carrier — plus the rule-inserted *implicit* units (hamza-waṣl connecting vowel,
+iltiqāʾ kasra, the Allah dagger-alef, the madd-ʿiwaḍ alef). A downstream forced
+aligner's per-phoneme timestamps then drive per-diacritic cell highlighting.
+
+The output is **canonical domain knowledge only** — roles, statuses, tajweed rule
+tags, and phoneme indices. No script/visual details (mini-meem glyphs, open/closed
+tanween forms, above/below placement, dotted-circle bases) are baked here; a consumer
+(e.g. the Inspector) derives all of that from the rule ``tag`` + the diacritic char.
+
+Each cell carries ``phoneme_indices`` — **word-local** indices into the word's phoneme
+sequence (``word.phonemes`` order, == the order a forced aligner's per-word phones
+follow). They are taken from the **raw per-letter walk** (the same walk
+``Phonemizer._build_alignment`` and ``madd.build_madd_mappings`` use), never a
+redistributed view: iltiqāʾ demotion and waqf-tanween redistribution change which
+*cell displays* a phoneme, never the phoneme's index. An index referenced by more than
+one cell is always an intentional shared-timing group (long vowel: haraka + carrier).
+
+This module is purely additive — it reads ``get_mapping()`` read-only and changes
+nothing about the letter-phoneme, silent, or tajweed outputs.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from .mapping import PhonemizationMapping, WordMapping, LetterMapping
+from .letter_phoneme_mapping import (
+    should_split_extension,
+    is_madd_phoneme,
+    get_full_char,
+    VOWEL_LETTER_CHARS,
+    TANWEEN_DIACRITICS,
+    SHORT_VOWEL_PHONEMES,
+)
+from .silent import sounding_in_flat
+
+
+# =============================================================================
+# Vocabulary (canonical, JSON-friendly string constants)
+# =============================================================================
+
+# Roles
+BASE = "base"        # consonant / consonantal vowel-letter / hamza / hamza-wasl
+HARAKA = "haraka"    # fatha / damma / kasra / sukun
+TANWEEN = "tanween"  # fathatan / dammatan / kasratan
+MADD = "madd"        # long-vowel carrier: ا و ي ى, mini ۥ ۦ ۧ, dagger-alef ٰ
+
+# Statuses
+PRESENT = "present"      # explicit, sounded
+INSERTED = "inserted"    # implicit, no source char
+DROPPED = "dropped"      # source char present but silent in this context
+REPLACED = "replaced"    # sound changed from the written form (madd-iwad)
+SHORTENED = "shortened"  # long vowel reduced; carrier silenced (iltiqaa)
+
+# Diacritic name -> its Unicode char (the phonemizer's canonical text).
+_DIAC_CHAR: Dict[str, str] = {
+    "FATHA": "َ", "DAMMA": "ُ", "KASRA": "ِ", "SUKUN": "ْ",
+    "FATHATAN": "ً", "DAMMATAN": "ٌ", "KASRATAN": "ٍ",
+}
+
+_HARAKA_DIACRITICS = {"FATHA", "DAMMA", "KASRA"}
+_QALQALA_PHONEMES = {"Q", "QQ"}
+# Mini-yaa-middle (U+06E7) behaves as a vowel letter (carrier i: or consonant j).
+_VOWEL_LETTERS = set(VOWEL_LETTER_CHARS) | {"ۧ"}
+
+# Source-rule -> tag priority for picking a cell's canonical case tag.
+_TANWEEN_RULE_TAGS = (
+    "iqlab_tanween", "ikhfaa_tanween",
+    "idgham_ghunnah_tanween", "idgham_bila_ghunnah_tanween",
+)
+_NOON_RULE_TAGS = (
+    "iqlab_noon", "ikhfaa_noon",
+    "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
+)
+
+
+# =============================================================================
+# Data classes
+# =============================================================================
+
+@dataclass
+class Cell:
+    """One written-character (or implicit) cell.
+
+    ``phoneme_indices`` are **word-local** indices into the word's phoneme
+    sequence; ``[]`` means the cell is silent in this context.
+    """
+    chars: str
+    role: str
+    status: str
+    phonemes: List[str] = field(default_factory=list)
+    phoneme_indices: List[int] = field(default_factory=list)
+    tag: Optional[str] = None
+    share_group: Optional[int] = None
+    source_letter_index: int = -1
+    source_letter_indices: List[int] = field(default_factory=list)
+
+    def to_list(self) -> list:
+        return [
+            self.chars, self.role, self.status,
+            list(self.phonemes), list(self.phoneme_indices),
+            self.tag, self.share_group,
+            self.source_letter_index, list(self.source_letter_indices),
+        ]
+
+    def to_dict(self) -> dict:
+        return {
+            "chars": self.chars,
+            "role": self.role,
+            "status": self.status,
+            "phonemes": list(self.phonemes),
+            "phoneme_indices": list(self.phoneme_indices),
+            "tag": self.tag,
+            "share_group": self.share_group,
+            "source_letter_index": self.source_letter_index,
+            "source_letter_indices": list(self.source_letter_indices),
+        }
+
+
+@dataclass
+class CharWord:
+    location: str
+    text: str
+    is_starting: bool
+    is_stopping: bool
+    cells: List[Cell] = field(default_factory=list)
+
+
+# =============================================================================
+# Per-letter helpers
+# =============================================================================
+
+def _source_rules(lm: LetterMapping) -> set:
+    return {t.rule.value for t in lm.tajweed_rules if t.is_source}
+
+
+def _pick_tag(rules: set, order: Tuple[str, ...]) -> Optional[str]:
+    for r in order:
+        if r in rules:
+            return r
+    return None
+
+
+def _letter_pairs(word: WordMapping) -> List[List[Tuple[int, str]]]:
+    """Per-letter list of (word_local_phoneme_index, phoneme) — the RAW walk."""
+    out: List[List[Tuple[int, str]]] = []
+    idx = 0
+    for lm in word.letter_mappings:
+        pairs = [(idx + j, p) for j, p in enumerate(lm.phonemes)]
+        idx += len(lm.phonemes)
+        out.append(pairs)
+    return out
+
+
+def _lafdh_jalalah_indices(word: WordMapping) -> set:
+    """Word-local phoneme indices that are the implicit Allah dagger-alef madd."""
+    return {mm.phoneme_index for mm in word.madd_mappings
+            if mm.is_lafdh_jalalah and mm.phoneme_index >= 0}
+
+
+# =============================================================================
+# Builder
+# =============================================================================
+
+def _special_word_cells(word: WordMapping) -> List[Cell]:
+    """Muqaṭṭaʿāt / hardcoded words: one BASE cell per sounding letter."""
+    cells: List[Cell] = []
+    pairs = _letter_pairs(word)
+    for li, lm in enumerate(word.letter_mappings):
+        lp = pairs[li]
+        if not lp:
+            continue  # inert (e.g. trailing stop-sign entry " ۚ")
+        cells.append(Cell(
+            chars=get_full_char(lm), role=BASE, status=PRESENT,
+            phonemes=[p for _, p in lp], phoneme_indices=[i for i, _ in lp],
+            source_letter_index=li, source_letter_indices=[li],
+        ))
+    return cells
+
+
+def _word_cells(word: WordMapping) -> List[Cell]:
+    pairs = _letter_pairs(word)
+    n_letters = len(word.letter_mappings)
+    lafdh_idx = _lafdh_jalalah_indices(word)
+
+    cells: List[Cell] = []
+    # Routed-to-next-letter state, keyed by the *target* letter index.
+    force_dropped: set = set()              # iltiqaa: vowel letter silenced
+    force_madd_iwad: Dict[int, Tuple[int, str]] = {}  # li -> (index, phoneme) of the a:
+
+    for li in range(n_letters):
+        lm = word.letter_mappings[li]
+        lp = pairs[li]
+        diac = lm.diacritic
+        rules = _source_rules(lm)
+        full = get_full_char(lm)
+
+        # ---- a letter that was routed into by a previous letter --------------
+        if li in force_madd_iwad:
+            idx, ph = force_madd_iwad[li]
+            cells.append(Cell(
+                chars=full, role=MADD, status=REPLACED,
+                phonemes=[ph], phoneme_indices=[idx], tag="madd_iwad",
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+        if li in force_dropped:
+            cells.append(Cell(
+                chars=full, role=MADD, status=SHORTENED,
+                phonemes=[], phoneme_indices=[], tag="iltiqaa",
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+
+        # ---- split into consonant / modifier --------------------------------
+        # A letter may be raw-silent (lp empty) yet still carry a diacritic — e.g.
+        # an idgham-shafawi meem whose consonant merged cross-word AND whose vowel
+        # lengthened onto the next letter (مَّا). Such a letter flows through here
+        # so its diacritic still gets a cell (absorbed into the following madd).
+        if diac is not None or lm.has_shaddah:
+            cons_pairs, mod_pairs = lp[:1], lp[1:]
+        else:
+            cons_pairs, mod_pairs = lp, []
+
+        # Qalqala echo always rides the base cell.
+        q_pairs = [p for p in mod_pairs if p[1] in _QALQALA_PHONEMES]
+        mod_pairs = [p for p in mod_pairs if p[1] not in _QALQALA_PHONEMES]
+
+        # Extension split (dagger-alef / mini-waw / mini-yaa carrying a long vowel
+        # on the SAME letter): the madd phoneme moves to its own MADD cell.
+        split = should_split_extension(lm, word)
+        madd_pair = None
+        madd_chars = None
+        if split:
+            madd_chars, _ = split
+            # last madd phoneme among this letter's (non-Q) pairs
+            for p in reversed(cons_pairs + mod_pairs):
+                if is_madd_phoneme(p[1]):
+                    madd_pair = p
+                    break
+            if madd_pair is not None:
+                if madd_pair in mod_pairs:
+                    mod_pairs = [p for p in mod_pairs if p != madd_pair]
+                elif madd_pair in cons_pairs:
+                    cons_pairs = [p for p in cons_pairs if p != madd_pair]
+            base_chars = full.replace(madd_chars, "", 1)
+        else:
+            base_chars = full
+
+        base_pairs = cons_pairs + q_pairs
+
+        # Implicit Allah dagger-alef: a madd in mod with no grapheme.
+        allah_pair = None
+        if not split:
+            for p in list(mod_pairs):
+                if p[0] in lafdh_idx and is_madd_phoneme(p[1]):
+                    allah_pair = p
+                    mod_pairs = [q for q in mod_pairs if q != p]
+                    break
+
+        # ---- emit the letter-sound cell (BASE or MADD) ----------------------
+        base_is_vowel_carrier = (
+            diac is None and not lm.has_shaddah and lm.char in _VOWEL_LETTERS
+            and all(is_madd_phoneme(p[1]) for p in base_pairs) and base_pairs
+        )
+        base_role = MADD if base_is_vowel_carrier else BASE
+        base_tag = None
+        if base_role == BASE:
+            base_tag = (_pick_tag(rules, _NOON_RULE_TAGS)
+                        or ("qalqala" if q_pairs else None))
+        cells.append(Cell(
+            chars=base_chars, role=base_role,
+            status=PRESENT if base_pairs else DROPPED,
+            phonemes=[p for _, p in base_pairs],
+            phoneme_indices=[i for i, _ in base_pairs],
+            tag=base_tag,
+            source_letter_index=li, source_letter_indices=[li],
+        ))
+
+        # ---- madd extension cell --------------------------------------------
+        if split and madd_pair is not None:
+            cells.append(Cell(
+                chars=madd_chars, role=MADD, status=PRESENT,
+                phonemes=[madd_pair[1]], phoneme_indices=[madd_pair[0]],
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+
+        # ---- implicit Allah dagger-alef cell --------------------------------
+        if allah_pair is not None:
+            cells.append(Cell(
+                chars="", role=MADD, status=INSERTED,
+                phonemes=[allah_pair[1]], phoneme_indices=[allah_pair[0]],
+                tag="allah_dagger_alef",
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+
+        # ---- hamza-wasl pronounced: connecting vowel is implicit ------------
+        # When started on, ٱ sounds as [ʔ, V] with no written haraka; split the
+        # connecting vowel V into its own INSERTED cell (it has no source char).
+        if lm.char == "ٱ" and diac is None and len(base_pairs) >= 2:
+            base_cell = next(c for c in reversed(cells)
+                             if c.source_letter_index == li and c.role == BASE)
+            v_idx, v_ph = base_cell.phoneme_indices[1], base_cell.phonemes[1]
+            base_cell.phonemes = base_cell.phonemes[:1]
+            base_cell.phoneme_indices = base_cell.phoneme_indices[:1]
+            cells.append(Cell(
+                chars="", role=HARAKA, status=INSERTED,
+                phonemes=[v_ph], phoneme_indices=[v_idx], tag="hamza_wasl_vowel",
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+
+        # ---- haraka / tanween cell ------------------------------------------
+        if diac is None:
+            continue
+
+        diac_char = _DIAC_CHAR.get(diac, "")
+        is_tanween = diac in TANWEEN_DIACRITICS
+
+        # madd-iwad: tanween at stop where a madd (a:) is produced and the next
+        # letter is a silent alef/alef-maksura that should carry it.
+        if (is_tanween and word.is_stopping and mod_pairs
+                and is_madd_phoneme(mod_pairs[-1][1])
+                and li + 1 < n_letters
+                and word.letter_mappings[li + 1].char in ("ا", "ى")
+                and not pairs[li + 1]):
+            madd_iwad = mod_pairs[-1]
+            mod_pairs = [p for p in mod_pairs if p != madd_iwad]
+            force_madd_iwad[li + 1] = madd_iwad
+            cells.append(Cell(
+                chars=diac_char, role=TANWEEN, status=DROPPED,
+                phonemes=[], phoneme_indices=[], tag="madd_iwad",
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+
+        # iltiqaa kasra: izhar tanween + next-word hamza-wasl -> [V, n, i]; the
+        # trailing kasra is an inserted bridge cell.
+        iltiqaa_kasra = None
+        if is_tanween and len(mod_pairs) == 3 and mod_pairs[-1][1] == "i":
+            iltiqaa_kasra = mod_pairs[-1]
+            mod_pairs = mod_pairs[:-1]
+
+        if is_tanween:
+            tan_tag = _pick_tag(rules, _TANWEEN_RULE_TAGS)
+            status = PRESENT
+            if word.is_stopping and not mod_pairs:
+                status = DROPPED  # dammatan/kasratan dropped at waqf
+            cells.append(Cell(
+                chars=diac_char, role=TANWEEN, status=status,
+                phonemes=[p for _, p in mod_pairs],
+                phoneme_indices=[i for i, _ in mod_pairs], tag=tan_tag,
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            if iltiqaa_kasra is not None:
+                cells.append(Cell(
+                    chars="", role=HARAKA, status=INSERTED,
+                    phonemes=[iltiqaa_kasra[1]], phoneme_indices=[iltiqaa_kasra[0]],
+                    tag="iltiqaa_kasra",
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
+            continue
+
+        # plain haraka (fatha/damma/kasra) or sukun
+        if diac == "SUKUN":
+            cells.append(Cell(
+                chars=diac_char, role=HARAKA, status=PRESENT,
+                phonemes=[], phoneme_indices=[],
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+
+        if mod_pairs:
+            # straightforward short/long vowel sitting on this letter
+            cells.append(Cell(
+                chars=diac_char, role=HARAKA, status=PRESENT,
+                phonemes=[p for _, p in mod_pairs],
+                phoneme_indices=[i for i, _ in mod_pairs],
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+
+        if split and madd_pair is not None:
+            # long vowel via same-letter extension: haraka shares the madd index
+            cells.append(Cell(
+                chars=diac_char, role=HARAKA, status=PRESENT,
+                phonemes=[madd_pair[1]], phoneme_indices=[madd_pair[0]],
+                source_letter_index=li, source_letter_indices=[li],
+            ))
+            continue
+
+        # haraka with no own phoneme: absorbed by the following vowel letter.
+        nxt = li + 1
+        nxt_pairs = pairs[nxt] if nxt < n_letters else []
+        if nxt_pairs and word.letter_mappings[nxt].char in _VOWEL_LETTERS:
+            nidx, nph = nxt_pairs[0]
+            if sounding_in_flat(word, nxt) and is_madd_phoneme(nph):
+                # long vowel: haraka + carrier share the long-vowel index
+                cells.append(Cell(
+                    chars=diac_char, role=HARAKA, status=PRESENT,
+                    phonemes=[nph], phoneme_indices=[nidx],
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
+                continue
+            if not sounding_in_flat(word, nxt) and nph in SHORT_VOWEL_PHONEMES:
+                # iltiqaa shortening: haraka takes the short vowel; carrier silenced
+                cells.append(Cell(
+                    chars=diac_char, role=HARAKA, status=SHORTENED,
+                    phonemes=[nph], phoneme_indices=[nidx], tag="iltiqaa",
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
+                force_dropped.add(nxt)
+                continue
+
+        # fallback: emit an empty haraka cell (covered by index-coverage check)
+        cells.append(Cell(
+            chars=diac_char, role=HARAKA, status=DROPPED,
+            phonemes=[], phoneme_indices=[],
+            source_letter_index=li, source_letter_indices=[li],
+        ))
+
+    return cells
+
+
+def _assign_intra_word_share_groups(cells: List[Cell], start_gid: int) -> int:
+    """Group cells (within one word) that reference the same phoneme index."""
+    by_index: Dict[int, List[Cell]] = {}
+    for c in cells:
+        for i in c.phoneme_indices:
+            by_index.setdefault(i, []).append(c)
+    gid = start_gid
+    assigned: Dict[int, int] = {}  # phoneme index -> group id
+    for i, group in by_index.items():
+        if len(group) < 2:
+            continue
+        g = assigned.get(i)
+        if g is None:
+            g = gid
+            gid += 1
+        for c in group:
+            if c.share_group is None:
+                c.share_group = g
+        assigned[i] = g
+    return gid
+
+
+# Tagged cross-word idgham sources — the cell that carries the rule tag in the
+# CURRENT word. Tanwīn idgham tags a (present) TANWEEN cell; noon idgham tags the
+# (silent, dropped) NOON base. Both should share a co-light group with the
+# receiving word's first sounding base. (ikhfaa / iqlab are cross-word but do NOT
+# fully merge, so they are excluded.)
+_IDGHAM_SOURCE_TAGS = (
+    "idgham_ghunnah_tanween", "idgham_bila_ghunnah_tanween",
+    "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
+)
+
+# Cross-word idgham where a CONSONANT at the prev word's tail merges into the
+# next word's first consonant but carries NO tag on its cell — only idgham_shafawi
+# (م|مّ): its merger phoneme (m̃) lands on the prev word's tail, so the prev word's
+# last sounding base carries it while the receiving word's first base carries only
+# the following vowel. (Noon idgham is tag-detected above; its source base is
+# silent and the merger lands on the receiving word's head.)
+_CROSS_WORD_BASE_MERGE_RULES = frozenset({"idgham_shafawi"})
+
+
+def _is_cross_word_base_merge(prev_wm: WordMapping, curr_wm: WordMapping) -> bool:
+    """True if the word boundary is a consonant idgham whose two base graphemes
+    should co-light. Asks the phonemizer's tajweed rules where the merge fires
+    (source on the prev word's tail, target on the curr word's head) — mirrors the
+    cross-word bridge detector so the two stay in lockstep."""
+    if not prev_wm.letter_mappings or not curr_wm.letter_mappings:
+        return False
+    curr_targets = {
+        t.rule.value for t in curr_wm.letter_mappings[0].tajweed_rules if not t.is_source
+    }
+    for e in reversed(prev_wm.letter_mappings):
+        srcs = {t.rule.value for t in e.tajweed_rules if t.is_source}
+        if (srcs & curr_targets) & _CROSS_WORD_BASE_MERGE_RULES:
+            return True
+    return False
+
+
+def _link_cross_word(words: List[CharWord], wmaps: List[WordMapping], start_gid: int) -> int:
+    """Co-highlight cross-word idgham mergers: the two graphemes that voice as one
+    sound share a group, so the consumer lights both through the merger. Two shapes:
+
+      - tanwīn idgham — the tanwīn cell of word N and the first sounding cell of
+        word N+1 (the merger lands on N+1's head).
+      - consonant idgham (idgham shafawi م|مّ) — word N's last sounding BASE and
+        word N+1's first sounding BASE (the merger m̃ lands on N's tail; N+1's base
+        carries only the following vowel)."""
+    gid = start_gid
+    for wi in range(len(words) - 1):
+        cur, nxt = words[wi], words[wi + 1]
+        recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
+        if recv is None:
+            continue
+        # Tagged idgham → the source is the tagged cell on the current word: a
+        # tanwīn cell (idgham tanween) or the silent noon base (idgham noon).
+        source = next((c for c in cur.cells if c.tag in _IDGHAM_SOURCE_TAGS), None)
+        # Untagged consonant idgham (shafawi) → the source is the current word's
+        # last sounding base (it carries the merger phoneme; the receiver carries
+        # only the following vowel).
+        if source is None and _is_cross_word_base_merge(wmaps[wi], wmaps[wi + 1]):
+            source = next((c for c in reversed(cur.cells)
+                           if c.role == BASE and c.phoneme_indices), None)
+        if source is None:
+            continue
+        if source.share_group is None and recv.share_group is None:
+            source.share_group = recv.share_group = gid
+            gid += 1
+        else:
+            g = source.share_group if source.share_group is not None else recv.share_group
+            source.share_group = recv.share_group = g
+    return gid
+
+
+def build_char_phoneme_mapping(mapping: PhonemizationMapping) -> List[CharWord]:
+    words: List[CharWord] = []
+    gid = 0
+    for wm in mapping.words:
+        cells = (_special_word_cells(wm) if wm.is_special_word else _word_cells(wm))
+        gid = _assign_intra_word_share_groups(cells, gid)
+        words.append(CharWord(
+            location=wm.location, text=wm.text,
+            is_starting=wm.is_starting, is_stopping=wm.is_stopping, cells=cells,
+        ))
+    gid = _link_cross_word(words, mapping.words, gid)
+    return words
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+def validate(words: List[CharWord], mapping: PhonemizationMapping) -> List[str]:
+    violations: List[str] = []
+
+    for wi, (cw, wm) in enumerate(zip(words, mapping.words)):
+        n_ph = len(wm.phonemes)
+        # (1) index coverage: every word-local phoneme index referenced >=1 time
+        seen: Dict[int, int] = {}
+        for c in cw.cells:
+            for i in c.phoneme_indices:
+                if not (0 <= i < n_ph):
+                    violations.append(
+                        f"{wm.location}: cell {c.chars!r} index {i} out of range 0..{n_ph}")
+                seen[i] = seen.get(i, 0) + 1
+        missing = [i for i in range(n_ph) if i not in seen]
+        if missing:
+            violations.append(f"{wm.location}: phoneme indices not covered: {missing} "
+                              f"(phonemes={wm.phonemes})")
+        # (2) shared index => same share_group
+        for i, count in seen.items():
+            if count > 1:
+                groups = {c.share_group for c in cw.cells if i in c.phoneme_indices}
+                if None in groups or len(groups) != 1:
+                    violations.append(
+                        f"{wm.location}: phoneme index {i} shared by cells without one "
+                        f"share_group (groups={groups})")
+        # (3) char completeness: each letter's diacritic char appears in a cell
+        for li, lm in enumerate(wm.letter_mappings):
+            if lm.diacritic and not wm.is_special_word:
+                dc = _DIAC_CHAR.get(lm.diacritic, "")
+                anchored = [c for c in cw.cells if c.source_letter_index == li]
+                if dc and not any(dc in c.chars for c in anchored):
+                    violations.append(
+                        f"{wm.location}: letter {li} ({lm.char!r}) diacritic "
+                        f"{lm.diacritic} has no cell")
+
+    # (4) phonemes match the resolved phoneme strings at their indices
+    offset = 0
+    for cw, wm in zip(words, mapping.words):
+        for c in cw.cells:
+            for ph, i in zip(c.phonemes, c.phoneme_indices):
+                if 0 <= i < len(wm.phonemes) and wm.phonemes[i] != ph:
+                    violations.append(
+                        f"{wm.location}: cell {c.chars!r} phoneme {ph!r} != "
+                        f"phonemes[{i}]={wm.phonemes[i]!r}")
+        offset += len(wm.phonemes)
+
+    return violations
+
+
+# =============================================================================
+# Public result
+# =============================================================================
+
+@dataclass
+class CharPhonemeResult:
+    words: List[CharWord]
+    mapping: PhonemizationMapping
+    ref: str = ""
+
+    def to_list(self) -> list:
+        return [[c.to_list() for c in w.cells] for w in self.words]
+
+    def to_dict(self) -> dict:
+        return {
+            "ref": self.ref,
+            "words": [
+                {
+                    "location": w.location,
+                    "text": w.text,
+                    "is_starting": w.is_starting,
+                    "is_stopping": w.is_stopping,
+                    "cells": [c.to_dict() for c in w.cells],
+                }
+                for w in self.words
+            ],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+    def validate(self) -> List[str]:
+        return validate(self.words, self.mapping)
+
+    def save(self, path: str, indent: int = 2) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.to_json(indent=indent))

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -35,6 +35,7 @@ from .letter_phoneme_mapping import (
     should_split_extension,
     is_madd_phoneme,
     get_full_char,
+    get_merge_info,
     TANWEEN_DIACRITICS,
     SHORT_VOWEL_PHONEMES,
 )
@@ -94,6 +95,12 @@ MADD_RULE_TAGS = frozenset({
 # phone on its own letter, so the receiving مّيٓم letter's nasal carries the tag via
 # its target_rules.
 GLIDE_PHONEMES = frozenset({"j", "w"})
+
+# Qalqala tier order for a base cell: kubra (at waqf / a final sākin) wins over
+# sughra (mid-word). Picked from the letter's OWN source rules — a qalqala letter
+# carries exactly one of these — so the cell names the precise variant instead of
+# the bare "qalqala". Both stay uncoloured downstream (name-only).
+QALQALA_RULE_ORDER = ("qalqala_kubra", "qalqala_sughra")
 
 
 # =============================================================================
@@ -192,6 +199,38 @@ def _source_rules(lm: LetterMapping) -> set:
     return {t.rule.value for t in lm.tajweed_rules if t.is_source}
 
 
+# Flat-builder reasons (get_merge_info) that name a true no-rule silence gap — the
+# letter went silent with no recognised tajweed rule. These map to a single literal
+# ``silent_unclassified`` so a consumer can surface "we couldn't classify this".
+_SILENT_GAP_REASONS = frozenset({
+    "idgham_unknown", "vowel_lengthening_failure", "unknown_silent",
+})
+
+
+def _silent_cell_tag(lm: LetterMapping, word: WordMapping, li: int) -> Optional[str]:
+    """Source silence rule for a raw-silent letter cell (no phoneme at its slot).
+
+    Classified by the SAME flat-builder ``get_merge_info`` the silent-flags path
+    uses, so the cell names exactly why the grapheme went mute:
+
+      - idgham-source silence (noon/meem merging into the next letter), lam_shamsiyah,
+        hamza_wasl_silent, silent_iltiqaa_sakinayn → the rule's own value (meaningful,
+        recoverable),
+      - the ``vowel_silent`` catch-all → ``vowel_silent`` (kept whole — sub-reasons
+        not split),
+      - a true no-rule gap (idgham_unknown / vowel_lengthening_failure / unknown_silent)
+        → the literal ``silent_unclassified``.
+
+    Returns ``None`` for a mundane silence the caller leaves generic (a waqf sukun /
+    silah-drop never reaches here; this path is only the silent BASE letter cell)."""
+    reason = get_merge_info(lm, word, li).rule
+    if not reason:
+        return None
+    if reason in _SILENT_GAP_REASONS:
+        return "silent_unclassified"
+    return reason
+
+
 def _dropped_silah_chars(lm: LetterMapping, word: WordMapping) -> Optional[str]:
     """The mini-waw/mini-yaa ṣilah glyph on a pronoun-haa whose ṣilah dropped at
     waqf (so ``should_split_extension`` finds no madd phoneme to split out). Returns
@@ -234,16 +273,27 @@ def _lafdh_jalalah_indices(word: WordMapping) -> set:
 
 
 def _madd_type_indices(word: WordMapping) -> Dict[int, str]:
-    """Word-local phoneme index -> ``madd_<type>`` tag for every CLASSIFIED madd
-    (wajib_muttasil / jaiz_munfasil / lazim / arid_lissukun / leen).
+    """Word-local phoneme index -> ``madd_<type>`` tag for every madd, classified
+    or ṭabīʿī (wajib_muttasil / jaiz_munfasil / lazim / arid_lissukun / leen, else
+    plain ``madd_tabii``).
 
-    Regular ṭabīʿī madds (``madd_type is None``) and implicit-only entries
-    (``phoneme_index < 0``) are skipped, so they stay untagged. The carrier cell
-    reads its own phoneme index from this map; the paired haraka is never tagged
-    (a madd colours only the carrier grapheme)."""
-    return {mm.phoneme_index: f"madd_{mm.madd_type}"
-            for mm in word.madd_mappings
-            if getattr(mm, "madd_type", None) and mm.phoneme_index >= 0}
+    A ``madd_type is None`` entry is a regular ṭabīʿī madd and maps to
+    ``madd_tabii`` (uncoloured downstream, name-only) — EXCEPT the implicit Allah
+    dagger-alef (``is_lafdh_jalalah``), which keeps its own ``allah_dagger_alef``
+    tag (resolved at the call site) and so is excluded here. Implicit-only entries
+    (``phoneme_index < 0``) are skipped. The carrier cell reads its own phoneme
+    index from this map; the paired haraka is never tagged (a madd colours only the
+    carrier grapheme)."""
+    out: Dict[int, str] = {}
+    for mm in word.madd_mappings:
+        if mm.phoneme_index < 0:
+            continue
+        mtype = getattr(mm, "madd_type", None)
+        if mtype:
+            out[mm.phoneme_index] = f"madd_{mtype}"
+        elif not mm.is_lafdh_jalalah:
+            out[mm.phoneme_index] = "madd_tabii"
+    return out
 
 
 # =============================================================================
@@ -483,13 +533,23 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         )
         base_role = MADD if (base_is_vowel_carrier or waqf_vowel_carrier) else BASE
         base_tag = None
-        if base_role == BASE:
+        if base_role == BASE and not base_pairs:
+            # Raw-silent letter: name the source silence rule (idgham-source merge,
+            # lam_shamsiyah, hamza_wasl_silent, silent_iltiqaa_sakinayn, the
+            # vowel_silent catch-all) or the silent_unclassified no-rule gap.
+            base_tag = _silent_cell_tag(lm, word, li)
+        elif base_role == BASE:
             base_tag = (_pick_tag(rules, NOON_RULE_TAGS)
                         or _pick_tag(rules, GHUNNAH_BASE_TAGS)
                         or (madd_types.get(base_pairs[0][0]) if base_pairs else None)
-                        or ("qalqala" if q_pairs else None))
+                        or (_pick_tag(rules, QALQALA_RULE_ORDER) if q_pairs else None)
+                        or ("tafkheem" if "tafkheem" in rules else None))
         elif waqf_vowel_carrier:
-            base_tag = madd_types.get(base_pairs[0][0], "madd_arid_lissukun")
+            # ʿāriḍ-li-s-sukūn at the stop. A plain ṭabīʿī madd (now mapped to
+            # madd_tabii) does NOT override that — only a CLASSIFIED non-tabii type
+            # (the rare case the mapping already pins it) wins.
+            mtype = madd_types.get(base_pairs[0][0])
+            base_tag = mtype if (mtype and mtype != "madd_tabii") else "madd_arid_lissukun"
         elif base_pairs:  # standalone long-vowel carrier (ا/آ/و/ي) — its madd type
             base_tag = madd_types.get(base_pairs[0][0])
         # Compose the canonical shaddah onto a mushaddad base (the aligner's bare

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -342,7 +342,8 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
       - the merged/ikhfaa nasal (m̃ ñ ŋ …) gets the idgham/ikhfaa/ghunnah rule,
       - the long-vowel madd phone gets the madd rule; a name with no long vowel
         but a leen glide (عَيْن's يْ → j) puts the madd on the glide,
-      - the qalqala consonant AND its render-only Q echo get qalqala_kubra,
+      - the qalqala render-only Q echo gets qalqala_kubra (NOT the consonant — the
+        underline rides the bounce, matching the regular cell path),
       - a heavy istiʿlāʾ consonant ( صٓ's sˤ, طٰ's tˤ, قٓ's q) gets tafkheem on its
         spare slot (the heavy long vowel after it already carries its madd),
       - every other phone is None."""
@@ -376,12 +377,6 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
         else:
             tags.append(None)
 
-    # The qalqala consonant (the phone right before the Q echo) co-carries the rule
-    # so a renderer underlines the dāl/qāf itself, not just the silent echo.
-    if has_qalqala:
-        for k in range(1, len(lp)):
-            if is_render_only(lp[k][1]) and tags[k - 1] is None:
-                tags[k - 1] = "qalqala_kubra"
     # Tafkheem on the heavy istiʿlāʾ consonant (صٓ's sˤ / قٓ's q / طٰ's tˤ): its slot
     # is otherwise None (the heavy vowel after it already took its madd).
     if "tafkheem" in rules:

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -44,6 +44,7 @@ from .tajweed_classification import (
     CellStatus,
     TANWEEN_RULE_TAGS,
     NOON_RULE_TAGS,
+    GHUNNAH_BASE_TAGS,
     IDGHAM_SOURCE_TAG_VALUES,
     detect_cross_word_mergers,
 )
@@ -170,6 +171,19 @@ def _lafdh_jalalah_indices(word: WordMapping) -> set:
             if mm.is_lafdh_jalalah and mm.phoneme_index >= 0}
 
 
+def _madd_type_indices(word: WordMapping) -> Dict[int, str]:
+    """Word-local phoneme index -> ``madd_<type>`` tag for every CLASSIFIED madd
+    (wajib_muttasil / jaiz_munfasil / lazim / arid_lissukun / leen).
+
+    Regular ṭabīʿī madds (``madd_type is None``) and implicit-only entries
+    (``phoneme_index < 0``) are skipped, so they stay untagged. The carrier cell
+    reads its own phoneme index from this map; the paired haraka is never tagged
+    (a madd colours only the carrier grapheme)."""
+    return {mm.phoneme_index: f"madd_{mm.madd_type}"
+            for mm in word.madd_mappings
+            if getattr(mm, "madd_type", None) and mm.phoneme_index >= 0}
+
+
 # =============================================================================
 # Builder
 # =============================================================================
@@ -194,6 +208,7 @@ def _word_cells(word: WordMapping) -> List[Cell]:
     pairs = _letter_pairs(word)
     n_letters = len(word.letter_mappings)
     lafdh_idx = _lafdh_jalalah_indices(word)
+    madd_types = _madd_type_indices(word)
 
     cells: List[Cell] = []
     # Routed-to-next-letter state, keyed by the *target* letter index.
@@ -279,7 +294,11 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         base_tag = None
         if base_role == BASE:
             base_tag = (_pick_tag(rules, NOON_RULE_TAGS)
+                        or _pick_tag(rules, GHUNNAH_BASE_TAGS)
+                        or (madd_types.get(base_pairs[0][0]) if base_pairs else None)
                         or ("qalqala" if q_pairs else None))
+        elif base_pairs:  # standalone long-vowel carrier (ا/آ/و/ي) — its madd type
+            base_tag = madd_types.get(base_pairs[0][0])
         # Compose the canonical shaddah onto a geminated base (the aligner's bare
         # letter char carries none) so a renderer reads the geminate from chars
         # rather than re-deriving it from the phoneme shape.
@@ -295,19 +314,23 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         ))
 
         # ---- madd extension cell --------------------------------------------
+        # (dagger-alef / mini-waw / mini-yaa carrier on the same letter — its madd type)
         if split and madd_pair is not None:
             cells.append(Cell(
                 chars=madd_chars, role=MADD, status=PRESENT,
                 phonemes=[madd_pair[1]], phoneme_indices=[madd_pair[0]],
+                tag=madd_types.get(madd_pair[0]),
                 source_letter_index=li, source_letter_indices=[li],
             ))
 
         # ---- implicit Allah dagger-alef cell --------------------------------
+        # ṭabīʿī when continuing (tag=allah_dagger_alef); at waqf it becomes madd
+        # ʿāriḍ — the classified madd type wins so the carrier reads its rule.
         if allah_pair is not None:
             cells.append(Cell(
                 chars="", role=MADD, status=INSERTED,
                 phonemes=[allah_pair[1]], phoneme_indices=[allah_pair[0]],
-                tag="allah_dagger_alef",
+                tag=madd_types.get(allah_pair[0], "allah_dagger_alef"),
                 source_letter_index=li, source_letter_indices=[li],
             ))
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -850,21 +850,21 @@ def _assign_intra_word_share_groups(cells: List[Cell], start_gid: int) -> int:
 
 
 def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start_gid: int) -> int:
-    """Co-highlight cross-word idgham mergers: the two graphemes that voice as one
-    sound share a group, so the consumer lights both through the merger.
+    """Wire up cross-word idgham mergers between graphemes that voice as one sound.
 
     Boundaries come from the single ``detect_cross_word_mergers`` (the same detector
-    the SDK shard bridge tagger uses). Co-lighting is scoped — as before — to the
-    tagged noon/tanwīn idghams and the both-sound shafawi merge:
+    the SDK shard bridge tagger uses). Two outcomes per merger:
 
-      - tanwīn / noon idgham (``side == "curr"``, tagged) — the tagged cell of word
-        N and the first sounding base of word N+1 (the merger lands on N+1's head).
-      - consonant idgham shafawi (``both_sound``) — word N's last sounding BASE and
-        word N+1's first sounding BASE (the merger m̃ lands on N's tail; N+1's base
-        carries only the following vowel).
+      - **co-light** (the tagged noon/tanwīn idghams + the both-sound shafawi merge):
+        source and receiver share a group, so the consumer lights both through the
+        merger and un-greys the silent source.
+      - **target-tag only** (mutaqāribayn / mutajānisayn kāmil): the receiver carries
+        the source's idgham rule as a SECONDARY tag — so it underlines + names the rule
+        (stacking above its own base rule) — but there is NO share group, so the source
+        stays silent/greyed (no co-light), per the desired distinction.
 
-    (mutamathilayn / mutaqaribayn / mutajanisayn are bridges but not cell co-light
-    sources, matching the historical scope.)"""
+    mutāmathilayn is co-light; mutaqāribayn / mutajānisayn are target-tag only.
+    (Within-word mutajānisayn nāqiṣ is handled by ``_tag_within_word_naqis``.)"""
     gid = start_gid
     for m in detect_cross_word_mergers(mapping):
         cur, nxt = words[m.prev_word_index], words[m.curr_word_index]
@@ -877,12 +877,25 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
             recv = next((c for c in nxt.cells if c.role == BASE), None)
             source = next((c for c in reversed(cur.cells)
                            if c.role == BASE and c.phoneme_indices), None)
+            co_light = True
         elif m.rule in IDGHAM_SOURCE_TAG_VALUES:
             recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
             source = next((c for c in cur.cells if c.tag in IDGHAM_SOURCE_TAG_VALUES), None)
+            co_light = True
+        elif m.rule in CONSONANT_IDGHAM_RULE_TAGS:
+            recv = next((c for c in nxt.cells if c.role == BASE and c.phoneme_indices), None)
+            source = next((c for c in cur.cells if c.tag == m.rule), None)
+            co_light = False
         else:
             continue
         if recv is None or source is None:
+            continue
+        if not co_light:
+            # Target-tag only: the receiver underlines + names the rule (a `merge`-layer
+            # secondary, stacking above its own base rule), without sharing a group.
+            if (source.tag and source.tag != recv.tag
+                    and source.tag not in recv.secondary_tags):
+                recv.secondary_tags.append(source.tag)
             continue
         if source.share_group is None and recv.share_group is None:
             g = gid
@@ -914,11 +927,25 @@ def _link_cross_word(words: List[CharWord], mapping: PhonemizationMapping, start
     return gid
 
 
+def _tag_within_word_naqis(cells: List[Cell]) -> None:
+    """Tag the TARGET of a within-word mutajānisayn nāqiṣ (طت: بَسَطتَ) so it underlines
+    + names the rule alongside its sounding source. Both letters sound (nāqiṣ), so this
+    is a pure secondary-tag on the next base — no merger/share-group involved."""
+    NAQIS = "idgham_mutajanisayn_naqis"
+    for i, c in enumerate(cells):
+        if c.tag != NAQIS:
+            continue
+        tgt = next((t for t in cells[i + 1:] if t.role == BASE), None)
+        if tgt and tgt.tag != NAQIS and NAQIS not in tgt.secondary_tags:
+            tgt.secondary_tags.append(NAQIS)
+
+
 def build_char_phoneme_mapping(mapping: PhonemizationMapping) -> List[CharWord]:
     words: List[CharWord] = []
     gid = 0
     for wm in mapping.words:
         cells = (_special_word_cells(wm) if wm.is_special_word else _word_cells(wm))
+        _tag_within_word_naqis(cells)
         gid = _assign_intra_word_share_groups(cells, gid)
         words.append(CharWord(
             location=wm.location, text=wm.text,

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -52,6 +52,7 @@ from .phonemes import (
     VOWEL_CARRIER_CHARS,
     diacritic_chars,
     is_geminate,
+    is_nasalised,
     is_render_only,
     is_short_vowel,
 )
@@ -299,10 +300,15 @@ def _word_cells(word: WordMapping) -> List[Cell]:
                         or ("qalqala" if q_pairs else None))
         elif base_pairs:  # standalone long-vowel carrier (ا/آ/و/ي) — its madd type
             base_tag = madd_types.get(base_pairs[0][0])
-        # Compose the canonical shaddah onto a geminated base (the aligner's bare
-        # letter char carries none) so a renderer reads the geminate from chars
-        # rather than re-deriving it from the phoneme shape.
-        if base_pairs and is_geminate(base_pairs[0][1]) and SHADDA not in base_chars:
+        # Compose the canonical shaddah onto a mushaddad base (the aligner's bare
+        # letter char carries none) so a renderer reads the gemination from chars.
+        # A plain geminate (rˤrˤ, ll…) is detected from the phoneme; a mushaddad
+        # nūn/mīm sounds a NASALISED geminate (ñ/m̃, which is_geminate misses), so
+        # gate that on the letter's own shaddah — never adds one to an idgham
+        # receiver that merely sounds ñ/m̃ without a written shaddah (يَقُول's yāʾ).
+        if (base_pairs and SHADDA not in base_chars
+                and (is_geminate(base_pairs[0][1])
+                     or (is_nasalised(base_pairs[0][1]) and lm.has_shaddah))):
             base_chars = base_chars + SHADDA
         cells.append(Cell(
             chars=base_chars, role=base_role,

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -342,8 +342,9 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
       - the merged/ikhfaa nasal (m̃ ñ ŋ …) gets the idgham/ikhfaa/ghunnah rule,
       - the long-vowel madd phone gets the madd rule; a name with no long vowel
         but a leen glide (عَيْن's يْ → j) puts the madd on the glide,
-      - the qalqala render-only Q echo gets qalqala_kubra (NOT the consonant — the
-        underline rides the bounce, matching the regular cell path),
+      - the qalqala consonant carries qalqala_kubra (the render-only Q echo is NOT
+        an indexable phone, so a downstream shard drops it — the consonant is the
+        only slot the rule can ride; a renderer moves the underline to the echo),
       - a heavy istiʿlāʾ consonant ( صٓ's sˤ, طٰ's tˤ, قٓ's q) gets tafkheem on its
         spare slot (the heavy long vowel after it already carries its madd),
       - every other phone is None."""
@@ -377,6 +378,14 @@ def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Opti
         else:
             tags.append(None)
 
+    # The qalqala consonant (the phone right before the render-only Q echo) carries
+    # the rule: the echo itself is dropped by the indexable-only shard projection, so
+    # the consonant is the only durable slot. The renderer moves the underline to the
+    # echo cell at render time (matching the regular cell path).
+    if has_qalqala:
+        for k in range(1, len(lp)):
+            if is_render_only(lp[k][1]) and tags[k - 1] is None:
+                tags[k - 1] = "qalqala_kubra"
     # Tafkheem on the heavy istiʿlāʾ consonant (صٓ's sˤ / قٓ's q / طٰ's tˤ): its slot
     # is otherwise None (the heavy vowel after it already took its madd).
     if "tafkheem" in rules:

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -53,6 +53,7 @@ from .phonemes import (
     VOWEL_CARRIER_CHARS,
     diacritic_chars,
     is_geminate,
+    is_madd,
     is_nasalised,
     is_render_only,
     is_short_vowel,
@@ -85,11 +86,14 @@ MADD_RULE_TAGS = frozenset({
     "madd_tabii", "madd_lazim", "madd_arid_lissukun", "madd_leen",
     "madd_wajib_muttasil", "madd_jaiz_munfasil",
 })
-# Base-cell rule tags a muqaṭṭaʿ letter can carry (noon/ghunnah/idgham/qalqala) —
-# the order is the colour priority when a subword names several.
-SPECIAL_BASE_TAGS = (
-    NOON_RULE_TAGS + GHUNNAH_BASE_TAGS + tuple(IDGHAM_SOURCE_TAG_VALUES) + ("qalqala_kubra",)
-)
+# Per-phoneme rule families for the muqaṭṭaʿ phoneme_rule_tags walk. A nasal-rule
+# lands on the name's nasal phone (the merged m̃ of لَآم's idgham-shafawi, the ŋ of
+# عَيْن's ikhfaa); a madd-rule lands on the long-vowel (or the leen glide when the
+# name has no long vowel — عَيْن's يْ glide). The nasal rules are the noon + ghunnah
+# tag tuples; the merger SOURCE side (the لَآم closing م that merged away) leaves no
+# phone on its own letter, so the receiving مّيٓم letter's nasal carries the tag via
+# its target_rules.
+GLIDE_PHONEMES = frozenset({"j", "w"})
 
 
 # =============================================================================
@@ -123,7 +127,13 @@ class Cell:
 
     ``phoneme_indices`` are **word-local** indices into the word's phoneme
     sequence; ``[]`` means the cell is silent in this context.
-    """
+
+    ``phoneme_rule_tags`` is an OPTIONAL list parallel to ``phoneme_indices``
+    (same length), each entry a per-phoneme tajweed tag or ``None``. It is set
+    only on muqaṭṭaʿāt letter cells, whose single bare-letter grapheme sounds out
+    a multi-letter name carrying several distinct rules (the merged nasal, the
+    long-vowel madd, the leen glide, the qalqala echo). When empty, a consumer
+    falls back to the cell's single ``tag``."""
     chars: str
     role: str
     status: str
@@ -133,17 +143,21 @@ class Cell:
     share_group: Optional[int] = None
     source_letter_index: int = -1
     source_letter_indices: List[int] = field(default_factory=list)
+    phoneme_rule_tags: List[Optional[str]] = field(default_factory=list)
 
     def to_list(self) -> list:
-        """Full 9-field dump (incl. ``phonemes`` + ``source_letter_indices``). This
-        is the phonemizer's own serialization — NOT the 7-slot Timestamps shard
-        row, which a downstream consumer (the SDK) projects in a different field
-        order; do not conflate the two positionally."""
+        """Full dump (incl. ``phonemes`` + ``source_letter_indices`` +
+        ``phoneme_rule_tags``). This is the phonemizer's own serialization — NOT
+        the Timestamps shard row, which a downstream consumer (the SDK) projects
+        in a different field order; do not conflate the two positionally.
+        ``phoneme_rule_tags`` is appended last (additive slot) so a reader of an
+        older row tolerates its absence."""
         return [
             self.chars, self.role, self.status,
             list(self.phonemes), list(self.phoneme_indices),
             self.tag, self.share_group,
             self.source_letter_index, list(self.source_letter_indices),
+            list(self.phoneme_rule_tags),
         ]
 
     def to_dict(self) -> dict:
@@ -157,6 +171,7 @@ class Cell:
             "share_group": self.share_group,
             "source_letter_index": self.source_letter_index,
             "source_letter_indices": list(self.source_letter_indices),
+            "phoneme_rule_tags": list(self.phoneme_rule_tags),
         }
 
 
@@ -235,31 +250,90 @@ def _madd_type_indices(word: WordMapping) -> Dict[int, str]:
 # Builder
 # =============================================================================
 
-def _special_subword_tags(subword: dict) -> Tuple[Optional[str], Optional[str]]:
-    """(base_tag, madd_tag) for one spelled-out muqaṭṭaʿ name (a tajweed_mapping
-    subword). The madd tag colours the long-vowel carrier; the base tag carries any
-    noon/ghunnah/idgham/qalqala the name sounds (e.g. the لَآمْ idgham-shafawi, the
-    عَيْن ikhfaa-noon). qalqala_kubra is normalised to the plain ``qalqala`` the FE
-    duration logic + ``_word_cells`` use."""
-    rules: List[str] = []
+def _special_subword_rules(subword: dict) -> Tuple[set, set]:
+    """(source_rules, target_rules) flattened across a muqaṭṭaʿ name's entries.
+    Both sides matter for the per-phoneme walk: a cross-letter idgham's SOURCE م
+    (the لَآم tail that merged away) leaves no phone on its own letter, so the
+    receiving name's nasal carries the rule via its ``target_rules``."""
+    src: set = set()
+    tgt: set = set()
     for e in subword.get("entries", []):
-        rules.extend(e.get("source_rules", []))
-    madd_tag = next((r for r in rules if r in MADD_RULE_TAGS), None)
-    base_tag = _pick_tag(set(rules), SPECIAL_BASE_TAGS)
-    if base_tag == "qalqala_kubra":
-        base_tag = "qalqala"
-    return base_tag, madd_tag
+        src.update(e.get("source_rules", []))
+        tgt.update(e.get("target_rules", []))
+    return src, tgt
+
+
+def _special_madd_tag(rules: set) -> Optional[str]:
+    """The name's madd subtype (madd_lazim / madd_tabii …) — the muqaṭṭaʿ cell's
+    headline ``tag``. عَيْن's leen is named with a madd_lazim, so even a name with
+    no long-vowel phone reports its madd here (the cell underlines as madd)."""
+    return next((r for r in rules if r in MADD_RULE_TAGS), None)
+
+
+def _special_phoneme_tags(subword: dict, lp: List[Tuple[int, str]]) -> List[Optional[str]]:
+    """Per-phoneme tags for ONE muqaṭṭaʿ letter, parallel to ``lp`` (its
+    (index, phoneme) pairs). The name's rules are placed on the phone each
+    concerns, identified by phone shape within this single letter (each relevant
+    shape occurs at most once per name part):
+
+      - the merged/ikhfaa nasal (m̃ ñ ŋ …) gets the idgham/ikhfaa/ghunnah rule,
+      - the long-vowel madd phone gets the madd rule; a name with no long vowel
+        but a leen glide (عَيْن's يْ → j) puts the madd on the glide,
+      - the qalqala consonant AND its render-only Q echo get qalqala_kubra,
+      - every other phone is None.
+
+    madd_tabii / qalqala / tafkheem ride through here even though the FE palette
+    leaves them uncoloured (a faithful renderer keys the colour, not this list)."""
+    src, tgt = _special_subword_rules(subword)
+    rules = src | tgt
+    madd_tag = _special_madd_tag(rules)
+    nasal_tag = _pick_tag(rules, NOON_RULE_TAGS + GHUNNAH_BASE_TAGS)
+    has_qalqala = "qalqala_kubra" in rules
+    has_long_vowel = any(is_madd(ph) for _, ph in lp)
+
+    # The nasal rule lands on exactly ONE phone — the merger/ikhfaa target. Prefer
+    # a nasalised phone (the idgham m̃), else the first plain nasal (the ikhfaa ŋ);
+    # the name's other meem (مّيٓم's trailing م) is untouched.
+    nasal_pos = -1
+    if nasal_tag:
+        nasal_pos = next((k for k, (_, ph) in enumerate(lp) if is_nasalised(ph)), -1)
+        if nasal_pos < 0:
+            nasal_pos = next(
+                (k for k, (_, ph) in enumerate(lp) if ph in {"ŋ", "n", "m"}), -1)
+
+    tags: List[Optional[str]] = []
+    for k, (_, ph) in enumerate(lp):
+        if has_qalqala and is_render_only(ph):
+            tags.append("qalqala_kubra")
+        elif nasal_tag and k == nasal_pos:
+            tags.append(nasal_tag)
+        elif madd_tag and is_madd(ph):
+            tags.append(madd_tag)
+        elif madd_tag and not has_long_vowel and ph in GLIDE_PHONEMES:
+            tags.append(madd_tag)  # leen glide (عَيْن يْ → j)
+        else:
+            tags.append(None)
+
+    # The qalqala consonant (the phone right before the Q echo) co-carries the rule
+    # so a renderer underlines the dāl/qāf itself, not just the silent echo.
+    if has_qalqala:
+        for k in range(1, len(lp)):
+            if is_render_only(lp[k][1]) and tags[k - 1] is None:
+                tags[k - 1] = "qalqala_kubra"
+    return tags
 
 
 def _special_word_cells(word: WordMapping) -> List[Cell]:
     """Muqaṭṭaʿāt / hardcoded words: one cell per sounding letter. A spelled-out name
     renders as its single bare-letter grapheme (لام is one ل glyph, not ل+phantom-alef),
-    so each letter stays ONE cell — but it now carries a tajweed ``tag`` so the FE
-    underlines it. Tags come from the grapheme-aligned YAML ``tajweed_mapping`` (the
-    same source ``tajweed_mappings()`` trusts): a name with a long vowel becomes a
-    MADD cell tagged with its madd subtype (madd_lazim نُوٓنْ, madd_tabii هَا, …); a
-    pure-consonant name (the leen عَيْن, the closing رَا of الٓر) stays a BASE cell
-    carrying any noon/ghunnah/idgham/qalqala the name sounds."""
+    so each letter stays ONE cell. The cell's headline ``tag`` is the name's LETTER-tier
+    madd (madd_lazim نُوٓنْ / لَآم, madd_tabii هَا, عَيْن's leen → madd_lazim); the new
+    ``phoneme_rule_tags`` then carries the finer per-phone rules the bare-letter cell
+    would otherwise smear — the merged nasal's idgham_shafawi, the ikhfaa nasal's
+    ikhfaa_noon, the long vowel / leen glide's madd, the dāl/Q qalqala. Both come from
+    the grapheme-aligned YAML ``tajweed_mapping`` (the same source ``tajweed_mappings()``
+    trusts). A name with neither madd nor nasal (the أَلِفْ head of الٓم) stays an
+    untagged BASE cell."""
     cells: List[Cell] = []
     pairs = _letter_pairs(word)
     subwords = get_tajweed_mapping(word.location) or []
@@ -270,17 +344,18 @@ def _special_word_cells(word: WordMapping) -> List[Cell]:
             continue  # inert (e.g. trailing stop-sign entry " ۚ")
         subword = subwords[sub_i] if sub_i < len(subwords) else {}
         sub_i += 1
-        base_tag, madd_tag = _special_subword_tags(subword)
 
-        has_madd = any(is_madd_phoneme(ph) for _, ph in lp)
-        role = MADD if has_madd else BASE
-        # A madd name shows its madd colour (the headline 6-count for lazim); a
-        # consonant-only name shows its merge/ikhfaa rule.
-        tag = madd_tag if has_madd else base_tag
+        rule_tags = _special_phoneme_tags(subword, lp)
+        src, tgt = _special_subword_rules(subword)
+        madd_tag = _special_madd_tag(src | tgt)
+        # A named madd (every letter but the bare أَلِفْ head) underlines + groups
+        # as MADD; only a rule-free head stays a plain BASE cell.
+        role = MADD if madd_tag else BASE
         cells.append(Cell(
             chars=get_full_char(lm), role=role, status=PRESENT,
             phonemes=[p for _, p in lp], phoneme_indices=[i for i, _ in lp],
-            tag=tag, source_letter_index=li, source_letter_indices=[li],
+            tag=madd_tag, source_letter_index=li, source_letter_indices=[li],
+            phoneme_rule_tags=rule_tags,
         ))
     return cells
 

--- a/quranic_phonemizer/char_phoneme_mapping.py
+++ b/quranic_phonemizer/char_phoneme_mapping.py
@@ -333,21 +333,32 @@ def _word_cells(word: WordMapping) -> List[Cell]:
         diac_char = diacritic_chars().get(diac, "")
         is_tanween = diac in TANWEEN_DIACRITICS
 
-        # madd-iwad: tanween at stop where a madd (a:) is produced and the next
-        # letter is a silent alef/alef-maksura that should carry it.
+        # madd-iwad: tanween-fath at waqf realises a compensating madd (a:); the
+        # fatḥatan drops and the madd rides an alef. When a silent alef / alef-maksura
+        # is WRITTEN after it (عَلِيمًا) that grapheme carries it (force_madd_iwad
+        # routes the madd to the next letter's cell). When none is written — the word
+        # ends in hamza (مَآءً) — the alef is purely implicit: emit it as an INSERTED
+        # graphemeless MADD cell, exactly like the Allah dagger-alef.
         if (is_tanween and word.is_stopping and mod_pairs
-                and is_madd_phoneme(mod_pairs[-1][1])
-                and li + 1 < n_letters
-                and word.letter_mappings[li + 1].char in ("ا", "ى")
-                and not pairs[li + 1]):
+                and is_madd_phoneme(mod_pairs[-1][1])):
             madd_iwad = mod_pairs[-1]
             mod_pairs = [p for p in mod_pairs if p != madd_iwad]
-            force_madd_iwad[li + 1] = madd_iwad
             cells.append(Cell(
                 chars=diac_char, role=TANWEEN, status=DROPPED,
                 phonemes=[], phoneme_indices=[], tag="madd_iwad",
                 source_letter_index=li, source_letter_indices=[li],
             ))
+            if (li + 1 < n_letters
+                    and word.letter_mappings[li + 1].char in ("ا", "ى")
+                    and not pairs[li + 1]):
+                force_madd_iwad[li + 1] = madd_iwad
+            else:
+                cells.append(Cell(
+                    chars="", role=MADD, status=INSERTED,
+                    phonemes=[madd_iwad[1]], phoneme_indices=[madd_iwad[0]],
+                    tag="madd_iwad",
+                    source_letter_index=li, source_letter_indices=[li],
+                ))
             continue
 
         # iltiqaa kasra: izhar tanween + next-word hamza-wasl -> [V, n, i]; the

--- a/quranic_phonemizer/letter_phoneme_mapping.py
+++ b/quranic_phonemizer/letter_phoneme_mapping.py
@@ -18,6 +18,12 @@ from .mapping import (
     WordMapping,
     LetterMapping,
 )
+from .tajweed_classification import (
+    CROSS_WORD_MERGE_RULES,
+    CROSS_WORD_BOTH_MERGE_RULES,
+    CROSS_WORD_NON_MERGE_RULES,
+)
+from .phonemes import SHORT_VOWEL_PHONEMES
 
 
 # =============================================================================
@@ -32,36 +38,19 @@ NEXT_MERGE_TAJWEED_RULES: Set[TajweedRule] = {
     TajweedRule.SILENT_ILTIQAA_SAKINAYN,
 }
 
-# Silent at word-end → cross-word MERGE with next word's first letter
-CROSS_WORD_MERGE_TAJWEED_RULES: Set[TajweedRule] = {
-    TajweedRule.IDGHAM_GHUNNAH_NOON,
-    TajweedRule.IDGHAM_BILA_GHUNNAH_NOON,
-    TajweedRule.IDGHAM_MUTAJANISAYN_KAMIL,
-    TajweedRule.IDGHAM_MUTAMATHILAYN,
-    TajweedRule.IDGHAM_MUTAQARIBAYN,
-}
+# Cross-word merge re-attribution classes — the canonical membership lives in
+# tajweed_classification (the single owner); these are the mutable-set views
+# get_merge_info intersects against.
+CROSS_WORD_MERGE_TAJWEED_RULES: Set[TajweedRule] = set(CROSS_WORD_MERGE_RULES)
+CROSS_WORD_BOTH_MERGE_TAJWEED_RULES: Set[TajweedRule] = set(CROSS_WORD_BOTH_MERGE_RULES)
+CROSS_WORD_NON_MERGE_TAJWEED_RULES: Set[TajweedRule] = set(CROSS_WORD_NON_MERGE_RULES)
 
-# Within-word NEXT merge (same rules as cross-word but at non-final position)
+# Within-word NEXT merge (idgham at non-final position) — a within-word concern,
+# owned here.
 WITHIN_WORD_NEXT_MERGE_TAJWEED_RULES: Set[TajweedRule] = {
     TajweedRule.IDGHAM_MUTAMATHILAYN,
     TajweedRule.IDGHAM_MUTAQARIBAYN,
     TajweedRule.IDGHAM_MUTAJANISAYN_KAMIL,
-}
-
-# Cross-word MERGE where BOTH letters have phonemes (combined into one entry)
-CROSS_WORD_BOTH_MERGE_TAJWEED_RULES: Set[TajweedRule] = {
-    TajweedRule.IDGHAM_SHAFAWI,
-}
-
-# Non-merge cross-word: last letter has phonemes, just add space suffix
-CROSS_WORD_NON_MERGE_TAJWEED_RULES: Set[TajweedRule] = {
-    TajweedRule.IKHFAA_NOON,
-    TajweedRule.IQLAB_NOON,
-    TajweedRule.IKHFAA_TANWEEN,
-    TajweedRule.IQLAB_TANWEEN,
-    TajweedRule.IKHFAA_SHAFAWI,
-    TajweedRule.IDGHAM_GHUNNAH_TANWEEN,
-    TajweedRule.IDGHAM_BILA_GHUNNAH_TANWEEN,
 }
 
 # Vowel letter characters
@@ -70,8 +59,8 @@ VOWEL_LETTER_CHARS: Set[str] = {"ا", "و", "ي", "ى"}
 # Madd extension names eligible for splitting
 MADD_EXTENSION_NAMES: Set[str] = {"DAGGER_ALEF", "MADDAH", "MINI_WAW", "MINI_YA_END"}
 
-# Short vowel phonemes (for iltiqaa detection)
-SHORT_VOWEL_PHONEMES: Set[str] = {"a", "aˤ", "u", "i"}
+# SHORT_VOWEL_PHONEMES is imported from .phonemes (the canonical owner) and
+# re-exported here for existing consumers.
 
 # Tanween diacritic names
 TANWEEN_DIACRITICS: Set[str] = {"FATHATAN", "KASRATAN", "DAMMATAN"}

--- a/quranic_phonemizer/parser.py
+++ b/quranic_phonemizer/parser.py
@@ -259,12 +259,18 @@ class Parser:
                 letter.index_in_word = len(word.letters)
                 word.letters.append(letter)
 
-            # Populate _tajweed_rules from single-entry tajweed_mapping (non-muqattaat)
+            # Populate _tajweed_rules from the tajweed_mapping. Each subword is one
+            # spelled-out letter name aligned positionally to a sounding letter, so
+            # the letter inherits the union of its subword's per-grapheme source
+            # rules (a name's madd carrier + any noon/ghunnah/idgham it sounds). This
+            # covers the multi-subword muqattaat too, whose entries are per spelled
+            # grapheme — never 1:1 with the YAML letter_mappings.
             tajweed_mapping = special_data.get('tajweed_mapping')
-            if tajweed_mapping and len(tajweed_mapping) == 1:
-                tm_entries = tajweed_mapping[0].get('entries', [])
-                for letter, tm_entry in zip(word.letters, tm_entries):
-                    for rule_str in tm_entry.get('source_rules', []):
+            if tajweed_mapping:
+                for letter, sub_word in zip(word.letters, tajweed_mapping):
+                    rule_strs = [r for entry in sub_word.get('entries', [])
+                                 for r in entry.get('source_rules', [])]
+                    for rule_str in rule_strs:
                         try:
                             letter.add_tajweed_rule(
                                 TajweedRuleTag(rule=TajweedRule(rule_str), is_source=True))

--- a/quranic_phonemizer/phoneme_registry.py
+++ b/quranic_phonemizer/phoneme_registry.py
@@ -15,6 +15,7 @@ import yaml
 DATA_DIR = Path(__file__).resolve().parent / "resources"
 
 _BASE_CACHE: Dict[str, str] = {}
+_DIAC_CACHE: Dict[str, str] = {}
 _RULE_CACHE: Dict[str, Any] = {}
 _INITIALISED = False
 
@@ -23,7 +24,7 @@ _OVERRIDES: Dict[tuple, str] = {}
 
 
 def _init() -> None:
-    global _INITIALISED, _BASE_CACHE, _RULE_CACHE
+    global _INITIALISED, _BASE_CACHE, _DIAC_CACHE, _RULE_CACHE
     if _INITIALISED:
         return
 
@@ -38,6 +39,10 @@ def _init() -> None:
             phoneme = info.get("phoneme", "")
             if char:
                 _BASE_CACHE[char] = phoneme
+        for name, info in base_data.get("diacritics", {}).items():
+            char = info.get("char")
+            if char:
+                _DIAC_CACHE[name] = char
     else:
         raise FileNotFoundError(base_path)
 
@@ -73,6 +78,24 @@ def get_rule_phoneme(rule: str, key: str = "phoneme", default: str = "") -> str:
         return _OVERRIDES[override_key]
     section = _RULE_CACHE.get(rule, {})
     return section.get(key, default)
+
+
+def get_rule_section(rule: str) -> Dict[str, Any]:
+    """Return a whole rule section from ``rule_phonemes.yaml`` (e.g. ``"qalqala"``,
+    ``"idgham"``) as a dict, or ``{}``. Lets callers derive a set of values (the
+    qalqala echo markers, the idgham ``nasalized_map``) from the YAML rather than
+    hardcoding them."""
+    if not _INITIALISED:
+        _init()
+    return _RULE_CACHE.get(rule, {}) or {}
+
+
+def get_diacritic_chars() -> Dict[str, str]:
+    """Return the canonical diacritic name → Unicode char map (FATHA→ َ …) from
+    ``base_phonemes.yaml``."""
+    if not _INITIALISED:
+        _init()
+    return dict(_DIAC_CACHE)
 
 
 def set_phoneme_override(rule: str, key: str, phoneme: str) -> None:

--- a/quranic_phonemizer/phonemes.py
+++ b/quranic_phonemizer/phonemes.py
@@ -1,0 +1,96 @@
+"""Phoneme-shape predicates — the single source for "what kind of phone is this".
+
+Consumers (the cell builder, the SDK shard annotator, and — via the cell facts —
+the inspector) ask THESE functions instead of re-implementing string tests or
+re-listing phoneme sets. Two families:
+
+- **Algorithmic** (no data): ``is_madd``, ``is_short_vowel``, ``is_geminate``.
+- **YAML-derived** (lazy): ``is_nasalised`` / ``nasalised_phonemes`` (the idgham
+  ``nasalized_map``), ``is_render_only`` / ``render_only_phonemes`` (the qalqala
+  echo — render-only markers that carry no grapheme and are excluded from the
+  flat phoneme index), and ``diacritic_chars`` (the canonical diacritic name→char
+  map). These load the phoneme YAML on FIRST CALL only, so importing this module
+  (and ``quranic_phonemizer``) triggers no data load.
+"""
+
+from __future__ import annotations
+
+from . import phoneme_registry as _reg
+
+# Short vowel phonemes (the canonical owner — letter_phoneme_mapping re-exports).
+SHORT_VOWEL_PHONEMES: frozenset[str] = frozenset({"a", "aˤ", "u", "i"})
+
+# Letters that can carry a long vowel (ا و ي ى + the mini-yaa-middle ۧ) — the
+# canonical owner (madd re-exports as VOWEL_LETTERS).
+VOWEL_CARRIER_CHARS: frozenset[str] = frozenset({"ا", "و", "ي", "ى", "ۧ"})
+
+# Stripped before the geminate doubled-halves test: emphatic, length, ASCII
+# length colon, combining nasal tilde — none of which a geminate consonant carries.
+_GEMINATE_STRIP = str.maketrans("", "", "ˤː:̃")
+
+
+def is_madd(ph: str) -> bool:
+    """A long vowel (madd) phoneme — carries the length mark ``:``."""
+    return ":" in ph
+
+
+def is_short_vowel(ph: str) -> bool:
+    """A short vowel phoneme (``a``/``aˤ``/``u``/``i``)."""
+    return ph in SHORT_VOWEL_PHONEMES
+
+
+def is_geminate(ph: str) -> bool:
+    """A doubled (shaddah/idgham) consonant — two identical halves once emphatic /
+    length / tilde marks are stripped (``bb``, ``ll``, ``rˤrˤ`` …)."""
+    if not ph:
+        return False
+    base = ph.translate(_GEMINATE_STRIP)
+    n = len(base)
+    return n >= 2 and n % 2 == 0 and base[: n // 2] == base[n // 2:]
+
+
+# --- lazy YAML-derived sets --------------------------------------------------
+
+_NASAL: frozenset[str] | None = None
+_RENDER_ONLY: frozenset[str] | None = None
+_DIAC_CHARS: dict[str, str] | None = None
+
+
+def nasalised_phonemes() -> frozenset[str]:
+    """The nasalised merger phonemes (idgham ``nasalized_map`` values: ñ m̃ j̃ w̃)."""
+    global _NASAL
+    if _NASAL is None:
+        nmap = _reg.get_rule_section("idgham").get("nasalized_map", {}) or {}
+        _NASAL = frozenset(v for v in nmap.values() if v)
+    return _NASAL
+
+
+def is_nasalised(ph: str) -> bool:
+    """A nasalised merger phoneme (ñ m̃ j̃ w̃)."""
+    return ph in nasalised_phonemes()
+
+
+def render_only_phonemes() -> frozenset[str]:
+    """Render-only markers an aligner may store that are NOT letter-derived and so
+    are excluded from the flat phoneme index — the qalqala echo (``Q``). Derived
+    from the ``qalqala`` YAML section, so it tracks the data (e.g. a future ``QQ``)
+    instead of being hardcoded in every consumer."""
+    global _RENDER_ONLY
+    if _RENDER_ONLY is None:
+        _RENDER_ONLY = frozenset(
+            v for v in _reg.get_rule_section("qalqala").values() if v
+        )
+    return _RENDER_ONLY
+
+
+def is_render_only(ph: str) -> bool:
+    """True for a render-only marker (the qalqala echo) — see ``render_only_phonemes``."""
+    return ph in render_only_phonemes()
+
+
+def diacritic_chars() -> dict[str, str]:
+    """Canonical diacritic name → Unicode char (FATHA→ َ …), from the phoneme YAML."""
+    global _DIAC_CHARS
+    if _DIAC_CHARS is None:
+        _DIAC_CHARS = dict(_reg.get_diacritic_chars())
+    return _DIAC_CHARS

--- a/quranic_phonemizer/phonemizer.py
+++ b/quranic_phonemizer/phonemizer.py
@@ -21,6 +21,9 @@ from .specials import get_tajweed_mapping
 from .letter_phoneme_mapping import (
     FlatMappingResult, build_letter_phoneme_mapping,
 )
+from .char_phoneme_mapping import (
+    CharPhonemeResult, build_char_phoneme_mapping,
+)
 
 DATA_DIR = Path(__file__).resolve().parent / "resources"
 
@@ -461,6 +464,25 @@ class PhonemizeResult:
 
         return result
 
+    def character_phoneme_mappings(self, validate_result: bool = False) -> CharPhonemeResult:
+        """Build character-level (haraka/tanween) phoneme cells.
+
+        One cell per written character (base letter, haraka, tanween, long-vowel
+        carrier) plus rule-inserted implicit units, each carrying word-local
+        ``phoneme_indices`` for per-diacritic highlight timing. See
+        ``char_phoneme_mapping``.
+        """
+        mapping = self.get_mapping()
+        words = build_char_phoneme_mapping(mapping)
+        result = CharPhonemeResult(words=words, mapping=mapping, ref=self.ref)
+
+        if validate_result:
+            violations = result.validate()
+            if violations:
+                raise ValueError("Validation failed:\n" + "\n".join(violations))
+
+        return result
+
     def get_mapping(self) -> PhonemizationMapping:
         """Build the full phonemization mapping with alignment."""
         word_mappings = [word.build_mapping() for word in self._words]
@@ -682,6 +704,8 @@ class PhonemizeResult:
             path.write_text(self.tajweed_mappings().to_json(), encoding="utf-8")
         elif fmt == "letter_phoneme":
             path.write_text(self.letter_phoneme_mappings().to_json(), encoding="utf-8")
+        elif fmt == "char_phoneme":
+            path.write_text(self.character_phoneme_mappings().to_json(), encoding="utf-8")
         else:
             raise ValueError(f"Unknown format: {fmt}")
         return path

--- a/quranic_phonemizer/resources/special_words.yaml
+++ b/quranic_phonemizer/resources/special_words.yaml
@@ -492,3 +492,52 @@ letter_overrides:
     target_char: "ۨ"
     override_phonemes: ["ŋ"]
     override_tajweed: ["ikhfaa_noon"]
+
+  # ٱئْتُونِى — when STARTED on, the hamzat-wasl ٱ sounds its own [ʔ, i:] (a madd
+  # tabii) and the following yaa-hamza ئ goes silent (drops its ʔ), so the word
+  # opens ʔ i: t u: n i: instead of the wasl ʔ t u: n i:. wasl/stop are untouched.
+  - location: "10:79:3"
+    context: "starting"
+    target_char: "ٱ"
+    override_phonemes: ["ʔ", "i:"]
+    override_tajweed: ["madd_tabii"]
+  - location: "10:79:3"
+    context: "starting"
+    target_char: "ئ"
+    override_phonemes: []
+  - location: "12:50:3"
+    context: "starting"
+    target_char: "ٱ"
+    override_phonemes: ["ʔ", "i:"]
+    override_tajweed: ["madd_tabii"]
+  - location: "12:50:3"
+    context: "starting"
+    target_char: "ئ"
+    override_phonemes: []
+  - location: "12:54:3"
+    context: "starting"
+    target_char: "ٱ"
+    override_phonemes: ["ʔ", "i:"]
+    override_tajweed: ["madd_tabii"]
+  - location: "12:54:3"
+    context: "starting"
+    target_char: "ئ"
+    override_phonemes: []
+  - location: "12:59:5"
+    context: "starting"
+    target_char: "ٱ"
+    override_phonemes: ["ʔ", "i:"]
+    override_tajweed: ["madd_tabii"]
+  - location: "12:59:5"
+    context: "starting"
+    target_char: "ئ"
+    override_phonemes: []
+  - location: "46:4:18"
+    context: "starting"
+    target_char: "ٱ"
+    override_phonemes: ["ʔ", "i:"]
+    override_tajweed: ["madd_tabii"]
+  - location: "46:4:18"
+    context: "starting"
+    target_char: "ئ"
+    override_phonemes: []

--- a/quranic_phonemizer/resources/special_words.yaml
+++ b/quranic_phonemizer/resources/special_words.yaml
@@ -97,9 +97,9 @@ special_words:
       - char: "ا"
         phonemes: ["ʔ", "a", "l", "i", "f"]
       - char: "لٓ"
-        phonemes: ["l", "a:"]
+        phonemes: ["l", "a:", "m"]
       - char: "ر"
-        phonemes: ["m", "rˤ", "aˤ:"]
+        phonemes: ["rˤ", "aˤ:"]
       - char: " ۚ"
         phonemes: []
     tajweed_mapping:

--- a/quranic_phonemizer/tajweed_classification.py
+++ b/quranic_phonemizer/tajweed_classification.py
@@ -77,6 +77,12 @@ class MergerClass:
     both_sound: bool
     tanween_assimilates: bool
     flat_attr: str  # "merge" | "both" | "non_merge"
+    # The merger co-lights both graphemes (source ↔ receiver share a group, so the
+    # silent source un-greys + lights through the merger). True for the noon/tanwīn
+    # idghams, shafawi, and — among the consonant idghams — ONLY mutamāthilayn;
+    # mutaqāribayn / mutajānisayn are tagged (underline + tooltip) but NOT co-lit, so
+    # their source stays silent.
+    co_light: bool = False
 
 
 # One entry per cross-word-capable rule. The single source the derived views and
@@ -84,23 +90,23 @@ class MergerClass:
 CROSS_WORD_MERGERS: dict[TajweedRule, MergerClass] = {
     # --- bridges: noon idgham (merger on curr head) ---
     TajweedRule.IDGHAM_GHUNNAH_NOON:
-        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge", co_light=True),
     TajweedRule.IDGHAM_BILA_GHUNNAH_NOON:
-        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge", co_light=True),
     TajweedRule.IDGHAM_MUTAMATHILAYN:
-        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge", co_light=True),
     TajweedRule.IDGHAM_MUTAQARIBAYN:
         MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
     TajweedRule.IDGHAM_MUTAJANISAYN_KAMIL:
         MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
     # --- bridge: shafawi (merger on prev tail, both letters sound) ---
     TajweedRule.IDGHAM_SHAFAWI:
-        MergerClass(bridge=True, side="prev", both_sound=True, tanween_assimilates=False, flat_attr="both"),
+        MergerClass(bridge=True, side="prev", both_sound=True, tanween_assimilates=False, flat_attr="both", co_light=True),
     # --- bridges: tanwīn idgham (merger on curr head, tanwīn assimilates) ---
     TajweedRule.IDGHAM_GHUNNAH_TANWEEN:
-        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge", co_light=True),
     TajweedRule.IDGHAM_BILA_GHUNNAH_TANWEEN:
-        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge", co_light=True),
     # --- non-bridges: ikhfaa / iqlab (cross-word but non-merging) ---
     TajweedRule.IKHFAA_TANWEEN:
         MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
@@ -132,12 +138,12 @@ BOTH_SOUND_VALUES: frozenset[str] = frozenset(
     r.value for r, m in CROSS_WORD_MERGERS.items() if m.both_sound
 )
 
-# Bridge idghams whose SOURCE is a noon/tanwīn (these carry a rule tag on the
-# source cell and co-light cross-word; mutamathilayn/mutaqaribayn/mutajanisayn
-# are bridges too but are not cell-tagged sources, matching the historical scope).
+# Idghams whose SOURCE cell is found by its tag in `_link_cross_word` to co-light
+# with the receiver (curr-head mergers): the noon/tanwīn idghams + mutamāthilayn.
+# Shafawi co-lights too but via the `both_sound` branch (prev-tail), so it's excluded
+# here. mutaqāribayn/mutajānisayn are NOT co-lit (`co_light=False`) — tagged only.
 IDGHAM_SOURCE_TAG_VALUES: frozenset[str] = frozenset(
-    r.value for r, m in CROSS_WORD_MERGERS.items()
-    if m.bridge and ("noon" in r.value or "tanween" in r.value)
+    r.value for r, m in CROSS_WORD_MERGERS.items() if m.co_light and not m.both_sound
 )
 
 # Tanwīn rules whose nūn-sound assimilates → a renderer draws the open tanwīn form.
@@ -174,6 +180,14 @@ NOON_RULE_TAGS: tuple[str, ...] = (
 # missing cell tag on the source mīm.
 GHUNNAH_BASE_TAGS: tuple[str, ...] = (
     "noon_ghunnah", "meem_ghunnah", "ikhfaa_shafawi", "idgham_shafawi",
+)
+# Consonant idgham source rules carried on the source letter cell itself. The
+# fully-merged (silent) sources route through ``_silent_cell_tag``; this tuple
+# supplies the cell tag for the one whose source SOUNDS — mutajānisayn nāqiṣ — so it
+# still underlines + names the rule.
+CONSONANT_IDGHAM_RULE_TAGS: tuple[str, ...] = (
+    "idgham_mutamathilayn", "idgham_mutaqaribayn",
+    "idgham_mutajanisayn_kamil", "idgham_mutajanisayn_naqis",
 )
 
 

--- a/quranic_phonemizer/tajweed_classification.py
+++ b/quranic_phonemizer/tajweed_classification.py
@@ -167,6 +167,14 @@ NOON_RULE_TAGS: tuple[str, ...] = (
     "iqlab_noon", "ikhfaa_noon",
     "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
 )
+# Base-cell rules carried as a SOURCE on the letter itself (not a noon/tanwīn rule
+# routed to a diacritic): plain ghunnah on a mushaddad nūn/mīm, and the two meem-
+# sākin shafawi rules. ``idgham_shafawi`` also co-lights cross-word via
+# ``_link_cross_word`` (which assigns the share_group); this tuple supplies its
+# missing cell tag on the source mīm.
+GHUNNAH_BASE_TAGS: tuple[str, ...] = (
+    "noon_ghunnah", "meem_ghunnah", "ikhfaa_shafawi", "idgham_shafawi",
+)
 
 
 # =============================================================================

--- a/quranic_phonemizer/tajweed_classification.py
+++ b/quranic_phonemizer/tajweed_classification.py
@@ -1,0 +1,219 @@
+"""Cross-word tajweed merger classification + the single cross-word detector.
+
+This is the **one** place that answers "which tajweed rules behave how across a
+word boundary" and "where does a cross-word merger fire in a mapping". Everything
+that used to hand-maintain a subset of these rule names — the SDK's ``BRIDGE_RULES``
+/ ``_MERGER_ON_PREV``, the cell builder's ``_IDGHAM_SOURCE_TAGS`` /
+``_CROSS_WORD_BASE_MERGE_RULES``, the flat letter-mapping's ``CROSS_WORD_*`` sets,
+the FE's assimilating-tanwīn set — derives from the single ``CROSS_WORD_MERGERS``
+registry here.
+
+A rule's cross-word behaviour has several **orthogonal** axes, deliberately kept
+separate (collapsing them is what made the copies drift):
+
+- ``bridge`` — produces a co-light merger phoneme an aligner should tag as a
+  cross-word bridge tile (the 8 idgham mergers). ikhfaa/iqlab are cross-word but
+  non-merging, so ``bridge=False``.
+- ``side`` — where the merger phoneme sits: ``"prev"`` (the prev word's tail —
+  idgham shafawi only) or ``"curr"`` (the curr word's head — every other merger).
+- ``both_sound`` — both boundary letters voice (idgham shafawi).
+- ``tanween_assimilates`` — a tanwīn whose nūn-sound assimilates into the next
+  word, so a renderer draws the *open* tanwīn form rather than the stacked one.
+- ``flat_attr`` — the flat letter-mapping re-attribution class
+  (``"merge"`` / ``"both"`` / ``"non_merge"``). This is a DIFFERENT question from
+  ``bridge``: the two ``idgham_*_tanween`` rules are ``bridge=True`` *and*
+  ``flat_attr="non_merge"`` at once. Keeping them as separate columns preserves
+  both historical answers.
+
+The cell role/status string vocabulary lives here too (as ``str``-mixed enums so
+JSON serialisation is byte-identical to the former bare strings).
+
+Imports only ``tajweed_rule`` + the stdlib — no YAML, no mapping — so importing
+this module is cheap and triggers no data load.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .tajweed_rule import TajweedRule
+
+
+# =============================================================================
+# Cell vocabulary (str-mixed enums — values byte-identical to the former consts)
+# =============================================================================
+
+class CellRole(str, Enum):
+    """The per-character cell roles emitted by ``character_phoneme_mappings``."""
+    BASE = "base"        # consonant / consonantal vowel-letter / hamza / hamza-wasl
+    HARAKA = "haraka"    # fatha / damma / kasra / sukun
+    TANWEEN = "tanween"  # fathatan / dammatan / kasratan
+    MADD = "madd"        # long-vowel carrier: ا و ي ى, mini ۥ ۦ ۧ, dagger-alef ٰ
+
+    __str__ = str.__str__  # str()/f-string yield the value, not "CellRole.BASE"
+
+
+class CellStatus(str, Enum):
+    """The per-character cell statuses."""
+    PRESENT = "present"      # explicit, sounded
+    INSERTED = "inserted"    # implicit, no source char
+    DROPPED = "dropped"      # source char present but silent in this context
+    REPLACED = "replaced"    # sound changed from the written form (madd-iwad)
+    SHORTENED = "shortened"  # long vowel reduced; carrier silenced (iltiqaa)
+
+    __str__ = str.__str__
+
+
+# =============================================================================
+# Cross-word merger classification
+# =============================================================================
+
+@dataclass(frozen=True)
+class MergerClass:
+    """How one tajweed rule behaves across a word boundary (see module docstring)."""
+    bridge: bool
+    side: str  # "prev" | "curr"
+    both_sound: bool
+    tanween_assimilates: bool
+    flat_attr: str  # "merge" | "both" | "non_merge"
+
+
+# One entry per cross-word-capable rule. The single source the derived views and
+# the detector read from.
+CROSS_WORD_MERGERS: dict[TajweedRule, MergerClass] = {
+    # --- bridges: noon idgham (merger on curr head) ---
+    TajweedRule.IDGHAM_GHUNNAH_NOON:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+    TajweedRule.IDGHAM_BILA_GHUNNAH_NOON:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+    TajweedRule.IDGHAM_MUTAMATHILAYN:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+    TajweedRule.IDGHAM_MUTAQARIBAYN:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+    TajweedRule.IDGHAM_MUTAJANISAYN_KAMIL:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="merge"),
+    # --- bridge: shafawi (merger on prev tail, both letters sound) ---
+    TajweedRule.IDGHAM_SHAFAWI:
+        MergerClass(bridge=True, side="prev", both_sound=True, tanween_assimilates=False, flat_attr="both"),
+    # --- bridges: tanwīn idgham (merger on curr head, tanwīn assimilates) ---
+    TajweedRule.IDGHAM_GHUNNAH_TANWEEN:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
+    TajweedRule.IDGHAM_BILA_GHUNNAH_TANWEEN:
+        MergerClass(bridge=True, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
+    # --- non-bridges: ikhfaa / iqlab (cross-word but non-merging) ---
+    TajweedRule.IKHFAA_TANWEEN:
+        MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=True, flat_attr="non_merge"),
+    TajweedRule.IKHFAA_NOON:
+        MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="non_merge"),
+    TajweedRule.IQLAB_NOON:
+        MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="non_merge"),
+    TajweedRule.IQLAB_TANWEEN:
+        MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="non_merge"),
+    TajweedRule.IKHFAA_SHAFAWI:
+        MergerClass(bridge=False, side="curr", both_sound=False, tanween_assimilates=False, flat_attr="non_merge"),
+}
+
+
+# --- derived views (computed once) -------------------------------------------
+
+# The 8 cross-word merger rules an aligner tags as a bridge phone.
+BRIDGE_RULE_VALUES: frozenset[str] = frozenset(
+    r.value for r, m in CROSS_WORD_MERGERS.items() if m.bridge
+)
+
+# The lone rule whose merger sits at the PREV word's tail.
+MERGER_ON_PREV_VALUES: frozenset[str] = frozenset(
+    r.value for r, m in CROSS_WORD_MERGERS.items() if m.side == "prev"
+)
+
+# Both-letters-sound mergers (a consonant idgham whose two base graphemes co-light).
+BOTH_SOUND_VALUES: frozenset[str] = frozenset(
+    r.value for r, m in CROSS_WORD_MERGERS.items() if m.both_sound
+)
+
+# Bridge idghams whose SOURCE is a noon/tanwīn (these carry a rule tag on the
+# source cell and co-light cross-word; mutamathilayn/mutaqaribayn/mutajanisayn
+# are bridges too but are not cell-tagged sources, matching the historical scope).
+IDGHAM_SOURCE_TAG_VALUES: frozenset[str] = frozenset(
+    r.value for r, m in CROSS_WORD_MERGERS.items()
+    if m.bridge and ("noon" in r.value or "tanween" in r.value)
+)
+
+# Tanwīn rules whose nūn-sound assimilates → a renderer draws the open tanwīn form.
+TANWEEN_ASSIMILATES_VALUES: frozenset[str] = frozenset(
+    r.value for r, m in CROSS_WORD_MERGERS.items() if m.tanween_assimilates
+)
+
+# Flat letter-mapping re-attribution views (consumed by letter_phoneme_mapping).
+CROSS_WORD_MERGE_RULES: frozenset[TajweedRule] = frozenset(
+    r for r, m in CROSS_WORD_MERGERS.items() if m.flat_attr == "merge"
+)
+CROSS_WORD_BOTH_MERGE_RULES: frozenset[TajweedRule] = frozenset(
+    r for r, m in CROSS_WORD_MERGERS.items() if m.flat_attr == "both"
+)
+CROSS_WORD_NON_MERGE_RULES: frozenset[TajweedRule] = frozenset(
+    r for r, m in CROSS_WORD_MERGERS.items() if m.flat_attr == "non_merge"
+)
+
+# Ordered tag-priority tuples for picking a single tanwīn / noon rule tag on a
+# cell (a letter carries at most one, so the order is only a deterministic
+# tie-break). Owned here so they are not re-listed at the call site.
+TANWEEN_RULE_TAGS: tuple[str, ...] = (
+    "iqlab_tanween", "ikhfaa_tanween",
+    "idgham_ghunnah_tanween", "idgham_bila_ghunnah_tanween",
+)
+NOON_RULE_TAGS: tuple[str, ...] = (
+    "iqlab_noon", "ikhfaa_noon",
+    "idgham_ghunnah_noon", "idgham_bila_ghunnah_noon",
+)
+
+
+# =============================================================================
+# The single cross-word merger detector
+# =============================================================================
+
+@dataclass(frozen=True)
+class CrossWordMerger:
+    """One detected cross-word merger boundary in a mapping."""
+    prev_word_index: int
+    curr_word_index: int
+    rule: str
+    side: str          # "prev" | "curr"
+    both_sound: bool
+
+
+def detect_cross_word_mergers(mapping) -> list[CrossWordMerger]:
+    """Return every cross-word *bridge* merger in a ``PhonemizationMapping``.
+
+    A boundary fires when any source rule on the prev word (scanned END-TO-FRONT,
+    so a tanwīn's source on its carrying consonant is found) matches a target rule
+    on the curr word's FIRST letter and is one of the 8 ``bridge`` rules. The
+    first matching rule wins (``sorted(...)[0]`` tie-break — at most one fires in
+    practice). The lone cell builder + the SDK shard bridge tagger both consume
+    this, so "where does idgham fire" is implemented exactly once.
+    """
+    out: list[CrossWordMerger] = []
+    words = mapping.words
+    for i in range(len(words) - 1):
+        prev, curr = words[i], words[i + 1]
+        if not prev.letter_mappings or not curr.letter_mappings:
+            continue
+        curr_targets = {
+            t.rule.value for t in curr.letter_mappings[0].tajweed_rules if not t.is_source
+        }
+        rule = None
+        for e in reversed(prev.letter_mappings):
+            srcs = {t.rule.value for t in e.tajweed_rules if t.is_source}
+            cross = (srcs & curr_targets) & BRIDGE_RULE_VALUES
+            if cross:
+                rule = sorted(cross)[0]
+                break
+        if rule is None:
+            continue
+        mc = CROSS_WORD_MERGERS[TajweedRule(rule)]
+        out.append(CrossWordMerger(
+            prev_word_index=i, curr_word_index=i + 1,
+            rule=rule, side=mc.side, both_sound=mc.both_sound,
+        ))
+    return out


### PR DESCRIPTION
`character_phoneme_mappings()` is a new public API that maps one cell per written character — the base consonant, every haraka / tanween, and the long-vowel carrier — alongside the rule-inserted *implicit* units (hamza-waṣl connecting vowel, iltiqāʾ kasra, the Allah dagger-alef, the madd-ʿiwaḍ alef). Each cell carries its role, status, tajweed-rule tag, and **word-local phoneme indices**, so a downstream forced aligner's per-phoneme timestamps can drive per-diacritic cell highlighting.

The output is canonical domain knowledge only — no script/visual concerns (open vs stacked tanwīn, mini-meem glyphs, above/below placement) are baked in; a consumer derives all of that from the rule tag + diacritic char. Graphemes that voice as a single sound share a co-light `share_group`: long vowels (haraka + carrier) and the cross-word idgham mergers — tanwīn idgham, idgham shafawi (both meems), and idgham noon (the silent noon and the receiving consonant that carries the merger).

The module is purely additive: it reads `get_mapping()` read-only and changes nothing about the letter-phoneme, silent, or tajweed outputs. A `validate()` pass guards index coverage and share-group consistency, and the package now exports `Cell`, `CharWord`, and `CharPhonemeResult`. Cuts a **v2.8** release (new public API; version is tag-driven via setuptools-scm).
