### PR TITLE
Three schemas that were checked for shape and never for meaning

### DIFF
--- a/docs/adr/003-script-boundary.md
+++ b/docs/adr/003-script-boundary.md
@@ -548,6 +548,13 @@ derivation over canonical context, the Ledger separates them, which is what
 27:36:8 requires: one `Supply(ONSET = SILAH)` at that slot, and the ordinary
 long-ī derivation everywhere else.
 
+The separation is therefore the Ledger and `canon/derive/`, and nothing else.
+An earlier implementation also recorded the ambiguity as a `polysemous` section
+in each inventory, which named the senses and then left the scalar's primary
+declaration in force — a note about the problem rather than the mechanism that
+solves it. It has been removed; a scalar is ambiguous exactly when a `Supply`
+or a derivation says so.
+
 Consequence for **fixture 13**: it must assert both halves — `Onset.SILAH` at
 27:36:8 *and* `Nucleus.Long(I)` at a sample of the 38 — or it tests a scalar
 rather than a fact and passes for the wrong reason.

--- a/quranic_phonemizer/canon/draft.py
+++ b/quranic_phonemizer/canon/draft.py
@@ -36,6 +36,22 @@ class _Draft:
     annotations: frozenset[Annotation] = frozenset()
 
 
+def fact_of(draft, fact: SlotFact):
+    """What a draft currently says about one fact. The mirror of `set_fact`."""
+    match fact:
+        case SlotFact.LETTER:
+            return draft.letter
+        case SlotFact.ONSET:
+            return draft.onset
+        case SlotFact.NUCLEUS:
+            return draft.nucleus
+        case SlotFact.SAKT:
+            return draft.sakt_after
+        case SlotFact.ANNOTATION:
+            return draft.annotations
+    return None
+
+
 def set_fact(draft, drafts, fact: SlotFact, value, target: Target,
          scribe: Scribe | None = None, offset: int = -1) -> None:
     subject = draft if target is Target.HERE else (drafts[-1] if drafts else None)

--- a/quranic_phonemizer/canon/ledger.py
+++ b/quranic_phonemizer/canon/ledger.py
@@ -213,7 +213,7 @@ def load_ledger(path: Path, *, riwayah: Riwayah) -> Ledger:
         _assert(row, where=f"{path} asserts[{i}]")
         for i, row in enumerate(data.get("asserts") or ())
     )
-    _reject_orphan_assert(supplies, asserts, path)
+    _check_asserts(supplies, asserts, path)
     return Ledger(supplies, asserts)
 
 
@@ -266,14 +266,23 @@ def _reject_duplicate_supply(supplies: tuple[Supply, ...], path: Path) -> None:
         seen[key] = supply
 
 
-def _reject_orphan_assert(
+def _check_asserts(
     supplies: tuple[Supply, ...], asserts: tuple[Assert, ...], path: Path
 ) -> None:
-    keys = {(str(s.ref), s.fact) for s in supplies}
+    """An assert must have a supply to agree with, and must agree with it."""
+    by_key = {(str(s.ref), s.fact): s for s in supplies}
     for row in asserts:
-        if (str(row.ref), row.fact) not in keys:
+        supply = by_key.get((str(row.ref), row.fact))
+        if supply is None:
             raise LedgerError(
                 f"{path}: {row.script.value} asserts {row.fact.value} at "
                 f"{row.ref} with no supply to agree with. An assert is a "
                 f"witness, not an authority."
+            )
+        if supply.value != row.value:
+            raise LedgerError(
+                f"{path}: {row.script.value} asserts {row.fact.value} at "
+                f"{row.ref} is {row.value!r}, but the supply says "
+                f"{supply.value!r}. A witness that disagrees is a "
+                f"contradiction, not a witness."
             )

--- a/quranic_phonemizer/canon/passes.py
+++ b/quranic_phonemizer/canon/passes.py
@@ -19,15 +19,20 @@ from ..model.canon import (
     Quality,
     Short,
 )
+from ..model.inscription import SlotFact
 from ..orthography.adapter import Reading
 from .derive import Target, lexeme
-from .draft import set_fact
+from .draft import fact_of, set_fact
 from .ledger import Ledger, VerseSlot, WordSlot
 from .lexicon import Lexicon
 
 
 class LedgerAddressError(ValueError):
     """An entry for this verse that does not resolve to a slot."""
+
+
+class LedgerWitnessError(ValueError):
+    """A script asserted to write a fact that it does not write."""
 
 
 def word_of(reading: Reading, draft) -> int:
@@ -51,19 +56,51 @@ def apply_ledger(reading: Reading, drafts, ledger: Ledger, track) -> None:
     An entry that silently matches nothing is worse than no entry: it reads
     as coverage that was never checked.
     """
+    _check_witnesses(reading, drafts, ledger)
     for supply in ledger.supplies:
         if not _addresses(supply.ref, reading.verse):
             continue
-        ordinal = _ordinal(reading, drafts, supply.ref)
-        if ordinal is None or ordinal >= len(drafts):
-            raise LedgerAddressError(
-                f"{reading.verse}: ledger entry {supply.ref} does not resolve "
-                f"to a slot -- the verse has {len(drafts)} slots. The index is "
-                f"zero-based within its word; check the word number too."
-            )
-        _check_skeleton(reading, drafts, ordinal, supply)
+        ordinal = _resolve(reading, drafts, supply.ref)
+        _check_skeleton(reading, drafts, ordinal, supply.skeleton)
         set_fact(drafts[ordinal], drafts, supply.fact, supply.value, Target.HERE)
         track.from_ledger += 1
+
+
+def _check_witnesses(reading: Reading, drafts, ledger: Ledger) -> None:
+    """An assert claims this script writes the fact itself, so it is checked
+    before any supply is applied -- otherwise it agrees with the supply."""
+    for row in ledger.asserts:
+        if row.script is not reading.script:
+            continue
+        if not _addresses(row.ref, reading.verse):
+            continue
+        ordinal = _resolve(reading, drafts, row.ref)
+        _check_skeleton(reading, drafts, ordinal, row.skeleton)
+        written = fact_of(drafts[ordinal], row.fact)
+        # A draft holds the set of its annotations, so agreement is membership.
+        agrees = (
+            row.value in written
+            if row.fact is SlotFact.ANNOTATION
+            else written == row.value
+        )
+        if not agrees:
+            raise LedgerWitnessError(
+                f"{reading.verse} slot {ordinal}: {row.script.value} is said "
+                f"to write {row.fact.value} {row.value!r}, and writes "
+                f"{written!r}. An assert records what a script already says."
+            )
+
+
+def _resolve(reading: Reading, drafts, ref) -> int:
+    """The verse ordinal an entry names. Unresolvable is an error, not a skip."""
+    ordinal = _ordinal(reading, drafts, ref)
+    if ordinal is None or ordinal >= len(drafts):
+        raise LedgerAddressError(
+            f"{reading.verse}: ledger entry {ref} does not resolve to a slot "
+            f"-- the verse has {len(drafts)} slots. The index is zero-based "
+            f"within its word; check the word number too."
+        )
+    return ordinal
 
 
 def _addresses(ref, verse: VerseRef) -> bool:
@@ -86,17 +123,17 @@ def _ordinal(reading: Reading, drafts, ref) -> int | None:
     return span[ref.index] if 0 <= ref.index < len(span) else None
 
 
-def _check_skeleton(reading: Reading, drafts, ordinal: int, supply) -> None:
+def _check_skeleton(reading: Reading, drafts, ordinal: int, claimed: str) -> None:
     """The mandatory `skeleton` is what catches ordinal drift. Without it a
     Ledger entry silently starts describing a different slot."""
     word = word_of(reading, drafts[ordinal])
     actual = "".join(
         ABJAD[d.letter.value] for d in drafts if word_of(reading, d) == word
     )
-    if actual != supply.skeleton:
+    if actual != claimed:
         raise LedgerAddressError(
             f"{reading.verse} slot {ordinal}: ledger entry claims skeleton "
-            f"{supply.skeleton!r} but the word is {actual!r}. The ordinal has "
+            f"{claimed!r} but the word is {actual!r}. The ordinal has "
             f"drifted, or the entry names the wrong word."
         )
 

--- a/quranic_phonemizer/data/riwayat/hafs/ledger.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/ledger.yaml
@@ -60,11 +60,11 @@ supplies:
   - {slot: "27:36:8#3", skeleton: "ءتني", fact: ONSET, value: SILAH,
      citation: "Hafs; ithbat and hadhf of the yaa"}
 
-  # The four sakt sites. Both scripts write a mark for them, but Uthmani's
-  # `ۜ` is declared polysemous -- it is also a khilaf site -- so the adapter
-  # defers rather than deciding, which is what polysemous is for. Four
-  # locations, no rule can reach them, and every tajwid source lists exactly
-  # these four: the Ledger's own definition.
+  # The four sakt sites. Both scripts write `ۜ` at them, but what that mark
+  # supplies is LETTER = SEEN; the sakt is a second sense of the same scalar
+  # and no rule over canonical context can separate the two. Four locations,
+  # and every tajwid source lists exactly these four: the Ledger's own
+  # definition.
   # 18:1:11 `عِوَجَاۜ` is deliberately absent. Its skeleton is not the same in
   # the two scripts -- IndoPak builds the tanwin nun and Uthmani does not, which
   # is one of the L1 rows -- so a mandatory skeleton cannot match both. The

--- a/quranic_phonemizer/data/riwayat/hafs/scripts/indopak.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/scripts/indopak.yaml
@@ -104,8 +104,3 @@ advice:
   "ࣝ": PERMITTED_STOP
 
 structural: [" ", "‮", "٦", "͏"]
-
-polysemous:
-  "ٖ": [SILAH, LONG_VOWEL]
-  "ۜ": [SAKT, KHILAF_SITE]
-  "ࣕ": [ADVICE, KHILAF_SITE]

--- a/quranic_phonemizer/data/riwayat/hafs/scripts/uthmani.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/scripts/uthmani.yaml
@@ -95,9 +95,3 @@ advice:
   "ۛ": EITHER_STOP
 
 structural: [" ", "۞", "۩", "‏"]
-
-polysemous:
-  "ۜ": [SAKT, KHILAF_SITE]
-  "ۧ": [SILAH, LONG_VOWEL]
-  "ۦ": [SILAH, LONG_VOWEL]
-  "ۥ": [SILAH, LONG_VOWEL]

--- a/quranic_phonemizer/orthography/inventory.py
+++ b/quranic_phonemizer/orthography/inventory.py
@@ -36,7 +36,6 @@ _SECTIONS = {
     "decorates",
     "advice",
     "structural",
-    "polysemous",
 }
 
 
@@ -88,7 +87,6 @@ class MarkEntry:
     saying something about the one before it."""
     advice: StopAdvice | None = None
     structural: bool = False
-    polysemous: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -191,7 +189,6 @@ def load_inventory(
     _load_decorates(data, path, marks)
     _load_advice(data, path, marks)
     _load_structural(data, path, marks)
-    _load_polysemous(data, path, marks)
 
     overlap = sorted(set(letters) & set(marks))
     if overlap:
@@ -357,27 +354,3 @@ def _load_structural(data: Any, path: Path, marks: dict[str, MarkEntry]) -> None
         )
 
 
-def _load_polysemous(data: Any, path: Path, marks: dict[str, MarkEntry]) -> None:
-    """Declaring a scalar polysemous forces the adapter to defer to the
-    Ledger instead of guessing which sense applies."""
-    for char, senses in (data.get("polysemous") or {}).items():
-        where = f"{path} polysemous[{char!r}]"
-        if char not in marks:
-            raise InventoryError(
-                f"{where}: a polysemous scalar must also be declared in one of "
-                f"{sorted(_SECTIONS - {'polysemous'})}"
-            )
-        base = marks[char]
-        marks[char] = MarkEntry(
-            role=base.role,
-            cls=base.cls,
-            fact=base.fact,
-            value=base.value,
-            derivation=base.derivation,
-            decorates=base.decorates,
-            silences=base.silences,
-            omitted=base.omitted,
-            advice=base.advice,
-            structural=base.structural,
-            polysemous=tuple(str(s) for s in senses),
-        )

--- a/quranic_phonemizer/riwayat/tables.py
+++ b/quranic_phonemizer/riwayat/tables.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 from ..dataio import load_yaml, require_keys
 from ..model.canon import ABJAD, CanonLetter, Rule
-from ..rules.tables import Followers, Pairs
+from ..rules.tables import (
+    MEEM_OUTCOMES,
+    NOON_OUTCOMES,
+    PAIR_OUTCOMES,
+    Followers,
+    Pairs,
+)
 
 SCHEMA_VERSION = 1
 
@@ -49,17 +55,19 @@ def load_rule_tables(shared: Path, riwayah: Path | None = None) -> RuleTables:
     never = _letters(data["never_follows"], where)
     return RuleTables(
         followers_of_noon=_followers(
-            data["followers_of_noon"], never, where
+            data["followers_of_noon"], never, NOON_OUTCOMES,
+            f"{where} followers_of_noon",
         ),
         followers_of_meem=_followers(
-            data["followers_of_meem"], never, where
+            data["followers_of_meem"], never, MEEM_OUTCOMES,
+            f"{where} followers_of_meem",
         ),
         never_follows=never,
         qalqala=_letters(data["qalqala"], where),
         always_heavy=_letters(data["always_heavy"], where),
         sun_letters=_letters(data["sun_letters"], where),
         proclitics=_letters(data["proclitics"], where),
-        pairs=Pairs(_pairs(data["pairs"], where)),
+        pairs=Pairs(_pairs(data["pairs"], f"{where} pairs")),
     )
 
 
@@ -75,11 +83,19 @@ def _versioned(path: Path, keys: set[str], *, partial: bool = False) -> dict:
     return data
 
 
-def _rule(name: str, where: str) -> Rule:
+def _rule(name: str, outcomes: frozenset[Rule], where: str) -> Rule:
+    """A Rule the family reading this table can act on. Checking membership in
+    `Rule` alone would accept a madd rule as a follower of noon."""
     try:
-        return Rule(name)
+        rule = Rule(name)
     except ValueError:
         raise RuleTableError(f"{where}: {name!r} is not a Rule") from None
+    if rule not in outcomes:
+        raise RuleTableError(
+            f"{where}: {name!r} is a Rule but not one this table selects; it "
+            f"selects among {sorted(r.value for r in outcomes)}"
+        )
+    return rule
 
 
 def _letter(glyph: str, where: str) -> CanonLetter:
@@ -96,10 +112,11 @@ def _letters(names: list[str], where: str) -> frozenset[CanonLetter]:
 def _followers(
     block: dict[str, list[str]],
     never: frozenset[CanonLetter],
+    outcomes: frozenset[Rule],
     where: str,
 ) -> Followers:
     by_rule = {
-        _rule(name, where): _letters(letters, where)
+        _rule(name, outcomes, where): _letters(letters, where)
         for name, letters in block.items()
     }
     _reject_overlap(by_rule, where)
@@ -125,7 +142,7 @@ def _pairs(
 ) -> dict[tuple[CanonLetter, CanonLetter], Rule]:
     out: dict[tuple[CanonLetter, CanonLetter], Rule] = {}
     for name, entries in block.items():
-        rule = _rule(name, where)
+        rule = _rule(name, PAIR_OUTCOMES, where)
         for entry in entries:
             if len(entry) != 2:
                 raise RuleTableError(f"{where}: {name} entry {entry} is not a pair")

--- a/quranic_phonemizer/rules/tables.py
+++ b/quranic_phonemizer/rules/tables.py
@@ -6,6 +6,27 @@ from dataclasses import dataclass
 
 from ..model.canon import CanonLetter, Rule
 
+#: What a quiescent noon's table may name. The remainder is IKHFAA_HAQIQI, and
+#: IZHAR_MUTLAQ is derived within a word rather than selected by a letter.
+NOON_OUTCOMES = frozenset({
+    Rule.IZHAR_HALQI,
+    Rule.IDGHAM_BI_GHUNNAH,
+    Rule.IDGHAM_BILA_GHUNNAH,
+    Rule.IQLAB,
+})
+
+#: What a quiescent meem's table may name. The remainder is IZHAR_SHAFAWI.
+MEEM_OUTCOMES = frozenset({Rule.IKHFAA_SHAFAWI, Rule.IDGHAM_SHAFAWI})
+
+#: What the pair table may name. IDGHAM_MUTAMATHILAYN is absent: like into
+#: like fires on any repeated letter, so no pair needs listing.
+PAIR_OUTCOMES = frozenset({
+    Rule.IDGHAM_MUTAJANISAYN_KAMIL,
+    Rule.IDGHAM_MUTAJANISAYN_NAQIS,
+    Rule.IDGHAM_MUTAQARIBAYN,
+})
+
+
 @dataclass(frozen=True, slots=True)
 class Followers:
     """Which outcome each following letter selects. Disjoint by construction;

--- a/tests/test_khilaf.py
+++ b/tests/test_khilaf.py
@@ -90,3 +90,33 @@ def test_the_riwayah_inherits_what_it_does_not_override() -> None:
     bare = load_rule_tables(shared / "rules.yaml")
     assert bare.qalqala == rule_tables().qalqala
     assert bare.pairs.by_pair == rule_tables().pairs.by_pair
+
+
+@pytest.mark.parametrize(
+    ("block", "name"),
+    [
+        ("followers_of_noon", "madd_lazim"),
+        ("followers_of_meem", "izhar_halqi"),
+        ("pairs", "qalqala_sughra"),
+    ],
+)
+def test_a_table_may_not_name_an_outcome_its_family_cannot_act_on(
+    tmp_path, block: str, name: str
+) -> None:
+    """Falsifier: membership in `Rule` was the whole check, so a madd rule
+    loaded as a follower of noon and then never fired."""
+    from pathlib import Path
+
+    from quranic_phonemizer.riwayat.tables import RuleTableError, load_rule_tables
+
+    source = (
+        Path(__file__).resolve().parent.parent
+        / "quranic_phonemizer" / "data" / "shared" / "rules.yaml"
+    )
+    text = source.read_text(encoding="utf-8").replace(
+        f"{block}:\n", f"{block}:\n  {name}: [ب]\n", 1
+    )
+    path = tmp_path / "rules.yaml"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(RuleTableError, match="not one this table selects"):
+        load_rule_tables(path)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -168,6 +168,24 @@ def test_rejects_an_unknown_schema_version(tmp_path: Path) -> None:
         load_ledger(path, riwayah=Riwayah.HAFS)
 
 
+def test_rejects_an_assert_that_disagrees_with_its_supply(tmp_path: Path) -> None:
+    """Falsifier: only `(slot, fact)` was compared, so a witness could name a
+    different value than the authority it is supposed to agree with."""
+    path = write(
+        tmp_path,
+        """
+        supplies:
+          - {slot: "2:245#17", skeleton: "ويبصط", fact: LETTER,
+             value: SEEN, citation: "Shatibiyyah"}
+        asserts:
+          - {script: uthmani, slot: "2:245#17", skeleton: "ويبصط",
+             fact: LETTER, value: SAD}
+        """,
+    )
+    with pytest.raises(LedgerError, match="contradiction"):
+        load_ledger(path, riwayah=Riwayah.HAFS)
+
+
 def test_rejects_a_ledger_authored_for_another_riwayah(tmp_path: Path) -> None:
     """Falsifier: the key was required present but never read, so a ledger
     for another reading supplied its facts to this one."""
@@ -218,6 +236,31 @@ def test_an_entry_for_this_verse_that_does_not_resolve_is_an_error(
     )
     with pytest.raises(LedgerAddressError, match="does not resolve"):
         build(reading, lexicon=hafs.lexicon, ledger=beyond)
+
+
+def test_an_assert_the_script_does_not_write_is_an_error(hafs) -> None:
+    """Checked against the drafted slot before the supply overwrites it.
+
+    Falsifier: nothing read `Ledger.asserts`, so both rows were discarded.
+    """
+    from dataclasses import replace
+
+    from quranic_phonemizer.canon.build import build
+    from quranic_phonemizer.canon.ledger import Ledger
+    from quranic_phonemizer.canon.passes import LedgerWitnessError
+    from quranic_phonemizer.model.address import Script, VerseRef
+    from quranic_phonemizer.model.canon import Long
+
+    verse = VerseRef(6, 77)
+    reading = hafs.read(Script.UTHMANI, verse, hafs.words(verse))
+    hafs.build(reading)
+
+    wrong = Ledger(
+        hafs.ledger.supplies,
+        tuple(replace(row, value=Long(Quality.I)) for row in hafs.ledger.asserts),
+    )
+    with pytest.raises(LedgerWitnessError, match="uthmani is said to write"):
+        build(reading, lexicon=hafs.lexicon, ledger=wrong, passes=hafs.passes)
 
 
 def test_an_entry_for_another_verse_is_not_an_error(packed, hafs) -> None:


### PR DESCRIPTION
Items 7–9 from the audit backlog, stacked on #41. All three are the same defect: a field is parsed, syntax-checked, stored — and nothing acts on it.

## `ledger.asserts` had no runtime reader

`apply_ledger` ([canon/passes.py](quranic_phonemizer/canon/passes.py)) iterated `ledger.supplies` only. `Ledger.asserts` had no reader outside `ledger.py`, so the two shipped rows were parsed and discarded. The load-time check compared `(str(ref), fact)`, so an assert claiming `SAD` where the supply said `SEEN` loaded clean — the opposite of the docstring's "a witness, not an authority". ADR-003 §7 already specifies that the loader rejects "a `skeleton` that does not match"; it did not.

An `Assert` now means what it says: *this script writes the fact itself, so the `Supply` is a no-op here*.

- Checked **before** any supply is applied. After, and every assert would pass tautologically by agreeing with the value the supply just wrote.
- `_check_skeleton` runs against the assert's own skeleton, not the supply's. They can legitimately differ — the ledger's 18:1:11 note records that IndoPak builds the tanwin noon where Uthmani does not.
- A load-time value disagreement is rejected as a contradiction; a script that does not write what it is asserted to write raises `LedgerWitnessError` at build.
- `fact_of` in `canon/draft.py` is the mirror of `set_fact`, in the same file so a new `SlotFact` cannot be added to one and forgotten in the other.

Both shipped rows pass — verified before writing the check that Uthmani's own evidence already yields `hamza / Long(A)` at `6:77:2#1` and `6:78:2#1`, with an empty ledger. Falsified by flipping the asserted value in memory, which raises.

The address-resolution block is now `_resolve`, shared by both passes instead of duplicated.

## `rules.yaml` outcomes were checked against the whole `Rule` enum

`followers_of_noon: {madd_lazim: [ب]}` loaded fine and then never fired. The legal outcome sets now live in `rules/tables.py`, beside the classifiers whose `match` arms consume them, and `riwayat/tables.py` checks the family rather than the vocabulary:

- `NOON_OUTCOMES` — remainder `IKHFAA_HAQIQI`. `IZHAR_MUTLAQ` excluded: `noon_sakinah.py` derives it within a word, no letter selects it.
- `MEEM_OUTCOMES` — remainder `IZHAR_SHAFAWI`.
- `PAIR_OUTCOMES` — `IDGHAM_MUTAMATHILAYN` excluded: like into like fires on any repeated letter, so no pair needs listing.

Three parametrized falsifiers, one per block.

## `polysemous` is deleted

It recorded that a scalar means more than one thing, then rebuilt the `MarkEntry` with its primary role intact — so the adapter never deferred, contrary to the field's own docstring. Of the seven declarations, only IndoPak `ٖ` had two senses of the *same* `SlotFact`; the rest were contested across different facts (`ۜ` supplies `LETTER: SEEN`, and `SAKT` is a different fact) and so could never collide.

Every fact it hinted at is already owned by something that acts on it — the Ledger holds the sakt sites, `khilaf.yaml` the khilaf sites, the `evidences` row the primary sense. ADR-003 §6.6 already states the real mechanism: *no declaration may be justified per scalar, only per site class, and where classes cannot be separated by a derivation the Ledger separates them.* That is the Ledger and `canon/derive/`, not an inventory annotation.

Deleted from `orthography/inventory.py` and both script YAMLs. The ledger comment that cited it as the reason the sakt sites are authored is rewritten to the actual reason. ADR-003 §6.6 gains a paragraph recording the removal. Because the section list feeds `require_keys`, a stale `polysemous:` block is now a load error — verified.

## Gates

Eight green, no floor moved.

| gate | result |
|---|---|
| suite | 238 passed, 1 skipped (was 233) |
| comment_lint | 0 problems in 89 files |
| structure_lint | 0 problems in 63 files |
| cross word / verse | 99.997% / 100.000% |
| regression word / verse | 99.928% / 97.674% |
| roundtrip uthmani | 100.000% |
| attest uthmani / indopak | 178 / 239 |
| l1 | 18 |

## Note for the seen/sad khilaf work

`KHILAF_SITE` on `ۜ` and IndoPak `ࣕ` was the only written record that those scalars are khilaf sites. That belongs in `khilaf.yaml` alongside the four sites, which is the next item.
