### PR TITLE
A constant that restates a data file becomes the data, or a check against it

### DIFF
--- a/docs/adr/010-constants-that-restate-data.md
+++ b/docs/adr/010-constants-that-restate-data.md
@@ -1,0 +1,124 @@
+# ADR-010: A constant that restates a data file becomes the data, or a check against it
+
+Status: **accepted**. Closes the Warsh-agnostic half of open design questions
+01 and 04. Audit: "Data versus code", and "Enforcement".
+
+## Context
+
+Five findings sat in two design documents, and they read as five chores. They
+are one shape. Each is a Python constant that restates something a data file
+already says, or enforces a data rule from the wrong place:
+
+| constant | what it restated | disposition |
+|---|---|---|
+| `cluster.SEATABLE` | which glyphs of Hafs a hamza may rest on | data: a `seat:` capability per scalar |
+| role literals | inventory role names, 14 of them | a check: `role-vocabulary` |
+| `lexicon.CLITIC_PRONOUNS` | Arabic's attached pronouns | data: `data/shared/morphology.yaml` |
+| `lexicon.BUDGETS` | a ceiling per lexicon section | data: `budget:`, checked by a test |
+| lexicon section names | the sections of `lexicon.yaml` | data: one `sections:` mapping |
+
+The common failure is that neither copy knows about the other. A frozenset of
+four glyphs cannot be wrong about Hafs, but it cannot be right about Warsh
+either, and nothing would say so. A role name misspelled in Python read
+`False` and changed output silently, which is exactly what `requires` was
+introduced to prevent and never actually did.
+
+## Decision
+
+**A constant that restates data becomes the data.** A seat is a capability the
+script declares, beside `onset`, `dagger_host`, `bare_rasm` and `rasm_only` —
+which is a route the inventory already had. The clitic pronouns are Arabic and
+go to `data/shared/`, not under `hafs/`, which would assert something false
+about every other riwayah. A lexicon section states its own match mode and its
+own ceiling.
+
+**A constant that cannot become data becomes a check against it.** The role
+names in code are code — they are what a derivation reads. So they are checked:
+`structure_lint`'s new `role-vocabulary` collects every string the package
+hands to a role lookup and requires each to be a role some derivation declares
+or some inventory writes.
+
+**What is enforced at load, and what at a gate.** A fact the package cannot
+run without stays a load error: an unknown capability, an unknown match mode, a
+duplicate entry. A ceiling is a conformance concern and moves to a test, where
+a breach is a red build naming the section, its size and its ceiling — not a
+package that will not import.
+
+### Why the role check is a union and not per derivation
+
+The obvious check is that each `has()` call reads a subset of its derivation's
+`requires`. That check would be a lie. `requires` is not a description of what
+a body reads:
+
+- `hamzat_wasl` declares thirteen roles and its body is `del context; return
+  Sets(...)`. The thirteen belong to `wasl.is_wasl`, which `canon.build` calls
+  directly rather than through `resolve()`.
+- `pausal_length` declares nine and reads none. `carrier` declares ten, reads one.
+- Five `has()` sites in `derive/lexeme.py` sit in no registered derivation at
+  all. They pass only because `ALWAYS_RUN` drags in `carrier`'s over-broad set;
+  tightening `carrier` to what it reads would leave them undeclared and silent.
+- `juncture.py`, `spell.py`, `build.py` and `cluster.py` read role literals from
+  outside `canon/derive/` entirely.
+
+So the claim that is true today is the union: every role named in code is a
+role something declares. With the existing load-time contract check, which runs
+the other way — every role a named derivation requires is one the script writes
+— a one-character slip now fails on whichever side it is made.
+
+Tightening `requires` into a real description is worth doing and is not this
+decision. It is in design question 08, because `cross_word_noon` shows why it
+is not mechanical: the derivation deliberately declares nothing, since
+requiring IndoPak's convention would reject Uthmani for not writing something
+Uthmani does not write.
+
+### What this deliberately does not decide
+
+Everything in 01 and 04 that turns on a second riwayah is untouched and now
+lives in [08](../design/08-what-a-second-riwayah-decides.md):
+
+- **Shape A and shape B for mark semantics** — whether `Mark` carries typed
+  `fact`/`value`/`derivation`, or `Cluster` answers typed questions. `seat` is
+  shape C for one base-scalar capability, which is safe because a seat is a
+  property of a glyph in any script. Whether a *mark's* meaning is per-scalar is
+  the question 07 says may have a different answer in Warsh.
+- **`ALWAYS_RUN` and `SCRIPT_OPTIONAL`** — both are patches over the contract
+  check, and `SCRIPT_OPTIONAL`'s replacement, semantic alternative groups, needs
+  a third inventory to be checkable at all.
+- **`data/shared/rules.yaml` inheritance** — blocked on research into which
+  rule families are riwayah-invariant.
+
+Two items leave the open list instead of moving to 08:
+
+- **`schema_version` is per file.** `render/ipa.yaml` went to 2 in ADR-009 and
+  no other loader had to move; `lexicon.yaml` goes to 2 here and the other six
+  stay at 1. That is the evidence design question 04 asked for, and it argues
+  against one package-wide data version. A bump obliges exactly one thing: the
+  loader for that file rejects the old shape with a message naming both versions.
+- **`comment_lint`'s 84 ungrouped comment blocks** are a tooling chore, not a
+  design question. Recorded here so the backlog is not lost, and out of
+  `docs/design/` either way.
+
+## Rejected: leave `SEATABLE` alone until the Warsh sequence layer is settled
+
+The safest reading of design question 01 is that shape C should wait, because a
+capability that turns out to attach to a match rather than a scalar makes the
+schema change wasted. Rejected for `seat` specifically: the four inventory
+capabilities that already exist are per-scalar and have not been questioned, a
+seat is the same kind of fact — a property of how a glyph is drawn — and if
+Warsh needs a sequence-scoped capability it needs one whether or not `seat` is
+already a flag. The argument holds for mark semantics, which is why those stay
+open.
+
+## Evidence
+
+No output moves. All eight gates read exactly as they did before the change —
+cross 99.997/100.000, regression 99.928/97.674, roundtrip 100.000, attest
+178/239, l1 18 — and the two parity gates render every word of the Quran
+through both the seat branch and the lexicon.
+
+Three falsifiers were run by hand and each failed as it should: a role
+misspelled in Python is named by `role-vocabulary` at its line; a scalar whose
+script does not call it a seat stops folding a combining hamza; a section over
+its ceiling fails `tests/test_lexicon.py` with both numbers.
+
+The lexicon had no tests at all before this. It has fifteen.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ Read in order. 001–006 are the design; 007 is how it is laid out in code;
 | [007](007-package-and-conventions.md) | Package tree, module boundaries, data schemas, naming |
 | [008](008-conformance-and-phases.md) | Invariants, fixtures, the L1 harness, the reversal trigger, phase order |
 | [009](009-the-output-alphabet.md) | The output alphabet as entries plus composition, and what replaced row-count totality |
+| [010](010-constants-that-restate-data.md) | A constant that restates a data file becomes the data, or a check against it |
 
 ## What this is for
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -4,7 +4,12 @@ Superseded on 2026-07-26. Kept as decision history. **Nothing here describes
 the current codebase or the accepted design.** Each file carries a header
 explaining why it was archived.
 
-Two groups:
+Three groups:
+
+**Merged design questions** — `design/01`, `design/04` and `design/07` each
+stalled on the same question and were replaced by `docs/design/08`. What could
+be settled without answering it is ADR-010. Each carries its own header saying
+which half went where.
 
 **Pre-refactor snapshots** — `architecture-today.md` and
 `current-implementation-mapping.md` document the 35-module implementation that

--- a/docs/archive/design/01-mark-semantics.md
+++ b/docs/archive/design/01-mark-semantics.md
@@ -1,6 +1,12 @@
 # 01 - What a script inventory hands downstream
 
-Status: **open**. Audit: "Data versus code", first four bullets.
+> **Superseded.** Its Warsh-agnostic half -- `SEATABLE`, and checking role
+> names against what declares them -- landed as
+> [ADR-010](../../adr/010-constants-that-restate-data.md). Shapes A and B,
+> `ALWAYS_RUN` and `SCRIPT_OPTIONAL` moved to
+> [design question 08](../../design/08-what-a-second-riwayah-decides.md).
+
+Status: **superseded**. Audit: "Data versus code", first four bullets.
 
 ## The choice
 

--- a/docs/archive/design/04-data-schemas.md
+++ b/docs/archive/design/04-data-schemas.md
@@ -1,6 +1,12 @@
 # 04 - What a data file must say about itself
 
-Status: **open**. Audit: "Data versus code", last three bullets, and
+> **Superseded.** The lexicon sections, the budgets and the clitic pronouns
+> landed as [ADR-010](../../adr/010-constants-that-restate-data.md), which
+> also closes `schema_version` and rehomes the `comment_lint` chore. The
+> `rules.yaml` inheritance question moved to
+> [design question 08](../../design/08-what-a-second-riwayah-decides.md).
+
+Status: **superseded**. Audit: "Data versus code", last three bullets, and
 "Enforcement".
 
 ## The pattern behind all of it

--- a/docs/archive/design/07-warsh-readiness.md
+++ b/docs/archive/design/07-warsh-readiness.md
@@ -1,6 +1,11 @@
 # 07 - What must exist before a Warsh inventory can be written
 
-Status: **open**. Audit: "Riwayah". Evidence:
+> **Superseded.** Carried forward whole into
+> [design question 08](../../design/08-what-a-second-riwayah-decides.md),
+> which asks its blocking question once for the three documents that
+> stalled on it. Nothing here landed in code.
+
+Status: **superseded**. Audit: "Riwayah". Evidence:
 `warsh-script-codepoint-audit.md` and PR #37.
 
 ## The claim to test
@@ -15,7 +20,7 @@ false answer if anyone ran it.
 
 - The layering. A Warsh Score is a Score.
 - The Ledger, for facts no rule over canonical context can reach.
-- The khilaf mechanism, once [06](06-seen-sad-khilaf.md) has generalised it
+- The khilaf mechanism, once [06](../../design/06-seen-sad-khilaf.md) has generalised it
   past Hafs-shaped sections.
 - The composition root: a Warsh package is one row in `api.PACKAGES`.
 - Two-scripts-one-Score as a gate, **within** Warsh.

--- a/docs/design/06-seen-sad-khilaf.md
+++ b/docs/design/06-seen-sad-khilaf.md
@@ -81,8 +81,8 @@ with three consequences:
    overrides.
 3. The inventory declarations become a deferral -- the mark names the khilaf
    rather than carrying a value -- which is the mechanism
-   [01](01-mark-semantics.md) is deciding the shape of. These two documents
-   are coupled.
+   [08](08-what-a-second-riwayah-decides.md) is deciding the shape of, under
+   mark semantics. These two documents are coupled.
 
 ## What to audit before deciding
 

--- a/docs/design/08-what-a-second-riwayah-decides.md
+++ b/docs/design/08-what-a-second-riwayah-decides.md
@@ -1,0 +1,214 @@
+# 08 - What a second riwayah decides, and what waits on it
+
+Status: **open**. Replaces 01, 04 and 07, whose Warsh-agnostic halves landed as
+[ADR-010](../adr/010-constants-that-restate-data.md). Audit: "Riwayah", "Data
+versus code". Evidence: `research/evidence/warsh-script-codepoint-audit.md`
+and PR #37.
+
+## One question, three documents
+
+01 asked whether a script inventory hands downstream code a typed fact or a
+string. 04 asked what a data file must say about itself. 07 asked what must
+exist before a Warsh inventory can be written. They were three documents
+because they were written from three sections of the audit, and each stalled at
+the same place:
+
+> **Does a script fact attach to a scalar, or to a match?**
+
+`Inventory` maps one character to one entry. Every capability the loader knows
+— `onset`, `dagger_host`, `bare_rasm`, `rasm_only`, and now `seat` — is a
+property of a single scalar, and that is sufficient for both Hafs scripts. The
+codepoint audit records four Warsh facts it cannot express:
+
+- Warsh has no `U+0671`. Wasl is a multi-scalar sequence, not a glyph that
+  declares its own onset the way Uthmani's `ٱ` does.
+- `U+06EA`, `U+06EC` and `U+06DF` are sequence-dependent: what each supplies
+  depends on its neighbours, not on the scalar.
+- Tanween composes a haraka with a small meem — two scalars, one fact.
+- Several marks that are per-scalar in Hafs are positional in Warsh.
+
+Answer that, and 01's shape C is either right or wasted; 04's inheritance
+question knows what a riwayah is overriding; 07's inventory can be written.
+Answer anything else first and it may have to be redone.
+
+## The sequence layer
+
+A declarative sequence layer belongs in `orthography/`, its table in
+`riwayat/warsh/`. The design content is what a match may look at:
+
+| scope | expresses | risk |
+|---|---|---|
+| fixed-width neighbours | tanween composition, most of `06EA`/`06EC` | may not reach wasl |
+| within-cluster | anything on one base | wasl spans bases |
+| within-word | everything audited | a pattern language, and pattern languages grow |
+
+The narrowest scope that covers the audited cases is the right answer, and
+"the audited cases" is the thing to establish.
+
+**What makes this wrong.** If it needs within-word matching, it is a pattern
+language, and a pattern language in a data file is a rule engine wearing a
+schema — the exact thing the Ledger was scoped to avoid. Should the audit land
+there, stop: some of those facts belong in a Warsh derivation in code rather
+than in the inventory.
+
+## What waits on the answer
+
+### Mark semantics (was 01)
+
+`Mark` carries `char`, `offset` and `role: str`. The loader parses which
+`SlotFact` a mark supplies, what value, and which derivation it defers to, then
+keeps only the string.
+
+The census, as it stands after ADR-010 — the earlier one counted
+`mark.role ==` comparisons, which are now three and all inside `orthography/`:
+
+| what | where |
+|---|---|
+| 16 `has()` calls with literal roles | `derive/wasl.py`, `derive/lexeme.py`, `derive/length.py` |
+| `HARAKAT` | `canon/spell.py:22` |
+| `VOWEL_ROLES` | `derive/wasl.py:16` and `derive/length.py:23` — same name, different value, sibling modules |
+| `QUIESCENT_BLOCKERS`, `_VOWEL_ROLES`, `CROSS_WORD_ROLE`, `DAGGER` | `derive/wasl.py`, `canon/build.py`, `derive/tanween.py`, `orthography/cluster.py` |
+| `_SHORT_ROLE` | `orthography/write.py:23`, a `Quality` mapped back to the role that writes it |
+
+`role-vocabulary` now checks every one of these against what a derivation or an
+inventory declares, so none of them can be misspelled. That is a floor, not the
+fix: they are still a second semantic API recovered by string comparison.
+
+**A.** Typed fields on `Mark`: `fact`, `value`, `derivation`, with `role` as
+diagnostic text. Cheapest — the loader stops discarding — but leaves `HARAKAT`,
+which asks whether a cluster has a vowel of its own, as a set membership test
+rather than a query.
+
+**B.** Typed queries on `Cluster`. The consumers do not want marks, they want
+answers. `derive/wasl.py` is the test case: if its questions do not reduce to a
+small closed set, this shape is wrong.
+
+A and B are not exclusive; B is the likely surface and A the mechanism under it.
+Neither can be sized until the sequence layer is settled, because a question
+answered from a match is not a question `Cluster` can answer.
+
+**To audit before deciding.** Every one of the 16 sites written as the question
+it is really asking. Two sites asking the same question in different words are
+one query, and the count of distinct queries is the size of shape B.
+
+### `requires` as a description rather than a proxy
+
+ADR-010 records why the role check is a union: `requires` over-declares
+massively. `hamzat_wasl` names thirteen roles and reads none of them; the
+thirteen belong to `wasl.is_wasl`, which `canon.build` calls directly.
+
+Making `requires` true would let the check become per derivation, which is
+strictly stronger. It is here rather than done because `cross_word_noon` shows
+it is not mechanical: that derivation declares nothing on purpose, since
+requiring IndoPak's convention would reject Uthmani for not writing something
+Uthmani does not write. `derive/tanween.py:52-57` states the deeper problem —
+`build._split_tanween_words` greps the role name, so a script fact decides a
+canonical question — and its own fix, which is for the derivation to return the
+slot rather than for the builder to look for the mark.
+
+### `ALWAYS_RUN` and `SCRIPT_OPTIONAL`
+
+Two frozensets in `orthography/inventory.py` that patch the contract check
+because it has no way to ask a derivation whether it runs unconditionally, or
+whether a role is one script's convention.
+
+`ALWAYS_RUN` is the three derivations `canon.build` names itself. Whether "runs
+even when no inventory names it" can be declared at registration is checkable
+today and is the smaller half.
+
+`SCRIPT_OPTIONAL` is not. Its four names are `silah_waw`, `silah_ya`,
+`small_waw`, `small_ya`, and the audit's proposed replacement is semantic
+alternative groups — a script must declare *one of* these, not *any subset*.
+That reading is checkable and the current one is not, but with two inventories
+both readings fit the data. A third is what tells them apart. Note also that
+`small_waw` and `small_ya` are inert: no `requires` names either, so the
+subtraction never reaches them.
+
+### `data/shared/rules.yaml` inheritance (was 04)
+
+A riwayah overrides the shared file one top-level key at a time; an omitted key
+is inherited silently. For Hafs that is correct — Hafs overrides nothing and
+the shared file *is* Hafs research. For Warsh an unwritten key and a
+deliberately identical key are indistinguishable in the file.
+
+Options: require each riwayah to state `inherits: [families]`; or require every
+family present and allow the value `shared`. Both make silence an error; the
+second needs no new vocabulary.
+
+**The research this waits on**, and it is research rather than engineering:
+`data/shared/rules.yaml` family by family, marked riwayah-invariant or
+Hafs-specific, with a source. Until that exists, "inherit" has no meaning to
+implement. `data/shared/morphology.yaml` is the first file placed on the
+invariant side deliberately, and it is a small one.
+
+## The Warsh work itself (was 07)
+
+### What transfers unchanged
+
+The layering — a Warsh Score is a Score. The Ledger, for facts no rule over
+canonical context can reach. The khilaf mechanism, once
+[06](06-seen-sad-khilaf.md) has generalised it past Hafs-shaped sections. The
+composition root: a Warsh package is one row in `api.PACKAGES`. And
+two-scripts-one-Score as a gate, **within** Warsh.
+
+### Cross-riwayah parity is invalid as a gate
+
+A riwayah is precisely a reading whose Score may differ. Comparing Hafs and
+Warsh output and requiring agreement tests for the absence of the thing being
+built. Anyone reaching for the existing parity harness on a Warsh corpus would
+get a number, and the number would mean nothing.
+
+Stated here because the harness is sitting there and it is the obvious next
+thing to point at.
+
+### The replacement: a per-riwayah conformance harness
+
+Six checks, none of which compares two riwayat:
+
+1. **Intake closure.** Every scalar in the corpus is classified by the
+   inventory. Fails loudly on an unaudited codepoint.
+2. **Inscription-Score closure.** Every grapheme reaches a slot or is
+   structural; every slot has a written source or a Ledger citation.
+3. **A reviewed rule matrix as the local oracle.** Warsh has no legacy
+   implementation to regress against, so the oracle has to be authored: a
+   matrix of rule against context with the expected outcome, reviewed against
+   sources before any code runs. This is the largest single piece of work on
+   this list and it is research, not engineering.
+4. **Hint agreement.** Source marks must never *drive* a rule — they witness
+   it. Same direction as today's attestation gate.
+5. **Certified differential alignment.** Where a Warsh site aligns with a Hafs
+   one, the difference falls into one of the five classes the codepoint audit
+   names. An unclassified difference is a finding, not a failure. This is what
+   people reach for parity wanting, stated so it is sound.
+6. **Internal completeness.** Every rule in the Warsh `RuleSet` fires at least
+   once over the corpus. A rule that never fires is unreviewed.
+
+### Corpus intake
+
+The Warsh text in PR #37 arrives from outside and will need normalisation.
+Whatever transform is applied has to be a checked manifest — input hash,
+transform, output hash — not a one-off script, or the corpus becomes
+unreproducible on the day someone asks where a codepoint went.
+
+## Ordering
+
+1. Sequence layer scope decided. Blocks the inventory, and blocks shapes A
+   and B above.
+2. Intake with a manifest. Blocks everything.
+3. Checks 1 and 2 — cheap, immediate, catch most intake errors.
+4. Rule matrix. Long, and parallel with the above.
+5. Which rule families are riwayah-invariant. Gates the inheritance decision;
+   also parallel.
+6. Checks 3 to 6, and `SCRIPT_OPTIONAL`, which a third inventory makes
+   decidable.
+
+## Acceptance
+
+- A Warsh inventory can be written without editing `orthography/`.
+- No gate compares Hafs output to Warsh output.
+- Every Warsh corpus file has a manifest naming its source and transform.
+- No module outside `orthography/` names a role at all, rather than merely
+  naming one that exists.
+- `HARAKAT`, `_SHORT_ROLE`, both `VOWEL_ROLES`, `ALWAYS_RUN` and
+  `SCRIPT_OPTIONAL` are gone from source.
+- A riwayah that omits a rule family fails to load with a message naming it.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,8 +1,10 @@
 # Open design questions
 
 Decisions that are still open, one document each. A document leaves this
-directory in one of two ways: it becomes a numbered ADR under `docs/adr/`, or
-it is closed as "no change" and moves to `docs/archive/`.
+directory in one of three ways: it becomes a numbered ADR under `docs/adr/`,
+it is closed as "no change", or it is merged into another document because it
+turned out to be asking that document's question. The first leaves a decision
+behind; the other two move the file to `docs/archive/`.
 
 These are not a backlog of known fixes. Everything in the July 2026 audit that
 had one correct answer and no design content has already landed. What is left
@@ -17,12 +19,10 @@ measured before choosing, and what would make the decision wrong.
 
 | | Question | Blocks |
 |---|---|---|
-| [01](01-mark-semantics.md) | Does a script inventory hand downstream code a typed fact or a string? | Warsh |
 | [03](03-canonical-vocabulary.md) | Do `Onset`, `SlotOrigin` and `Annotation` split? | projections |
-| [04](04-data-schemas.md) | What does a data file have to say about itself before it is trusted? | Warsh |
 | [05](05-build-internals.md) | Who owns slot adjacency, pass order, and slot identity? | nothing yet |
 | [06](06-seen-sad-khilaf.md) | How is the seen/sad khilaf authored and selected? | correctness today |
-| [07](07-warsh-readiness.md) | What must exist before a Warsh inventory can be written? | Warsh |
+| [08](08-what-a-second-riwayah-decides.md) | Does a script fact attach to a scalar or to a match? | Warsh |
 
 Read 06 first if you only read one. It is the only item on this list that is
 wrong today rather than merely awkward.
@@ -32,3 +32,10 @@ wrong today rather than merely awkward.
 | Was | Became |
 |---|---|
 | 02 — the output alphabet | [ADR-009](../adr/009-the-output-alphabet.md) |
+| 01 — mark semantics | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
+| 04 — data schemas | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
+| 07 — Warsh readiness | merged into 08 |
+
+01, 04 and 07 each stalled at the same question, which is why 08 asks it once.
+What could be settled without answering it landed as ADR-010; the archived
+originals are in `docs/archive/design/`.

--- a/quranic_phonemizer/canon/lexicon.py
+++ b/quranic_phonemizer/canon/lexicon.py
@@ -1,34 +1,29 @@
 """The canonical-skeleton lexicon: closed classes of Arabic, not of this corpus.
 
 Keyed by canonical letters so one entry serves every script of the riwayah.
-A budget ceiling turns growth past it into a build failure, not a silent list.
+The sections are data; the ways of matching one are a closed set in here.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 
 from ..dataio import load_yaml, require_keys
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
-#: Exceeding a budget fails the build instead of absorbing growth silently.
-#: `wasl_exempt` needs headroom because `ال` is genuinely ambiguous between
-#: the article and a root lam, with no orthographic test to tell them apart.
-BUDGETS = {
-    "wasl_particles": 10,
-    "wasl_exempt": 60,
-    "wasl_exempt_doubled": 10,
-    "pausal_lexemes": 10,
-    "form_eight_lam": 10,
-    "divine_name": 5,
-}
+#: Versioned per file, not per package: this one has never had to move.
+MORPHOLOGY_SCHEMA_VERSION = 1
 
-#: The attached pronouns, in canonical letters. Closed in Arabic, so a lexeme
-#: entry covers its whole inflectional family without enumerating it.
-CLITIC_PRONOUNS: frozenset[str] = frozenset(
-    {"ه", "هم", "هما", "هن", "ك", "كم", "كما", "كن", "نا", "ي", "ني", "همء"}
-)
+
+class MatchMode(StrEnum):
+    """How an entry is compared against the skeleton being tested."""
+
+    EXACT = "exact"
+    CLITIC = "clitic"
+    INFLECTED = "inflected"
+    PROCLITIC = "proclitic"
 
 
 #: Below this length a stem is not specific enough to match a prefix.
@@ -44,120 +39,155 @@ class LexiconError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class Section:
+    """One closed class: how to match it, and how large it may grow."""
+
+    match: MatchMode
+    budget: int
+    """A ceiling the gate enforces. Growth past it means a rule is missing,
+    not that the corpus is irregular, so it is reviewed rather than raised."""
+    entries: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
 class Lexicon:
-    wasl_particles: frozenset[str] = frozenset()
-    """`إن`, `إذ`, `إذا` - hamza-initial particles that look prosthetic."""
-    wasl_exempt: frozenset[str] = frozenset()
-    """Proper nouns and form-IV verbal nouns the three rules over-accept."""
-    wasl_exempt_doubled: frozenset[str] = frozenset()
-    """`ألَّف`, `إلَّم` - hamza plus a doubled lam that is not the article."""
-    wasl_kasra: frozenset[str] = frozenset()
-    """Words whose wasl hamza takes kasra although their third letter carries
-    damma, because that damma is not the stem's: `اسم`, `ٱمْشُوا۟`."""
-    pausal_lexemes: frozenset[str] = frozenset()
-    """The seven alifs: words whose final alif is short in wasl and long at
-    pause. IndoPak's script has no grapheme that distinguishes them, so the
-    absence of evidence is not a contradiction."""
-    form_eight_lam: frozenset[str] = frozenset()
-    """Form-VIII verbs whose first radical is lam, e.g. `ٱلْتَقَى`. After a
-    wasl hamza these look identical to the definite article before a sun
-    letter, and canonical facts alone cannot tell them apart."""
-    divine_name: frozenset[str] = frozenset()
-    """What the name of God spells from its doubled lam to the end of the
-    word. `ٱللَّهْوِ` and `ٱللَّهَبِ` open the same way and are not it."""
+    sections: dict[str, Section] = field(default_factory=dict)
+    clitics: frozenset[str] = frozenset()
+    """Arabic's attached pronouns. A closed set, so a stem entry covers its
+    whole inflectional family without enumerating it."""
     source: Path | None = field(default=None, compare=False)
 
     def is_divine_name(self, tail: str) -> bool:
         """The whole remainder of the word, so a third radical excludes it."""
-        return tail in self.divine_name
+        return self._matches("divine_name", tail)
 
     def is_wasl_exempt(self, skeleton: str) -> bool:
-        return _inflected(self.wasl_particles, skeleton) or _inflected(
-            self.wasl_exempt, skeleton
+        return self._matches("wasl_particles", skeleton) or self._matches(
+            "wasl_exempt", skeleton
         )
 
     def is_wasl_exempt_doubled(self, skeleton: str) -> bool:
-        return _inflected(self.wasl_exempt_doubled, skeleton)
+        return self._matches("wasl_exempt_doubled", skeleton)
 
     def is_pausal(self, skeleton: str) -> bool:
         """Matched exactly, or after a single proclitic: `وَأَنَا` is `أنا`."""
-        if skeleton in self.pausal_lexemes:
-            return True
-        return any(
-            len(skeleton) - len(entry) == _PROCLITIC and skeleton.endswith(entry)
-            for entry in self.pausal_lexemes
-        )
+        return self._matches("pausal_lexemes", skeleton)
 
     def takes_wasl_kasra(self, skeleton: str) -> bool:
         """Matched as it stands: `است` heads every form-X verb, whose helping
         vowel its own third letter decides."""
-        return _bare(self.wasl_kasra, skeleton)
+        return self._matches("wasl_kasra", skeleton)
 
     def is_form_eight_lam(self, skeleton: str) -> bool:
         """Matched as it stands: `ٱلتَّقْوَىٰ` and `ٱلتَّمَاثِيل` extend the
         stems of `ٱلْتَقَى` and `ٱلْتَمِسُوا` and are not them."""
-        return _bare(self.form_eight_lam, skeleton)
+        return self._matches("form_eight_lam", skeleton)
+
+    @property
+    def pausal_lexemes(self) -> frozenset[str]:
+        """The pass that applies them skips its whole loop when there are
+        none, so it asks for the entries rather than testing a skeleton."""
+        section = self.sections.get("pausal_lexemes")
+        return section.entries if section else frozenset()
+
+    def _matches(self, name: str, key: str) -> bool:
+        section = self.sections.get(name)
+        if section is None:
+            return False
+        return _MATCHERS[section.match](section.entries, key, self.clitics)
 
 
-def _bare(entries: frozenset[str], skeleton: str) -> bool:
-    """A lexeme, with or without a clitic pronoun.
+def _exact(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+    return key in entries
 
-    Arabic's clitic pronouns are a closed set, so matching stem plus pronoun
-    avoids enumerating every inflected form of `إيمان` separately.
-    """
-    return skeleton in entries or any(
-        skeleton == stem + clitic
-        for stem in entries
-        for clitic in CLITIC_PRONOUNS
+
+def _clitic(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+    """A lexeme, with or without a clitic pronoun."""
+    return key in entries or any(
+        key == stem + clitic for stem in entries for clitic in clitics
     )
 
 
-def _inflected(entries: frozenset[str], skeleton: str) -> bool:
+def _inflected(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
     """That, or a stem long enough to be specific as a prefix -- `ألقى`,
     `ألقينا`, `ألقوا` are one entry."""
-    return _bare(entries, skeleton) or any(
-        len(stem) >= _PREFIX_MIN and skeleton.startswith(stem)
-        for stem in entries
+    return _clitic(entries, key, clitics) or any(
+        len(stem) >= _PREFIX_MIN and key.startswith(stem) for stem in entries
     )
 
+
+def _proclitic(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+    return key in entries or any(
+        len(key) - len(entry) == _PROCLITIC and key.endswith(entry)
+        for entry in entries
+    )
+
+
+_MATCHERS = {
+    MatchMode.EXACT: _exact,
+    MatchMode.CLITIC: _clitic,
+    MatchMode.INFLECTED: _inflected,
+    MatchMode.PROCLITIC: _proclitic,
+}
 
 EMPTY = Lexicon()
 
 
-def _section(entries, name: str, path: Path) -> frozenset[str]:
+def _entries(raw, name: str, path: Path) -> frozenset[str]:
     """A repeated entry is rejected: a set would swallow it before the budget
     counts, so the file would show more rows than the ceiling ever sees."""
     seen: set[str] = set()
-    for entry in entries:
+    for entry in raw or ():
         if entry in seen:
             raise LexiconError(f"{path}: {name} lists {entry!r} twice")
         seen.add(entry)
     return frozenset(seen)
 
 
-def load_lexicon(path: Path) -> Lexicon:
-    data = load_yaml(path)
-    require_keys(
-        data,
-        {"schema_version"},
-        name=str(path),
-        optional=set(BUDGETS) | {"wasl_kasra"},
+def _section(raw, name: str, path: Path) -> Section:
+    where = f"{path} sections[{name}]"
+    require_keys(raw, {"match", "budget", "entries"}, name=where)
+    try:
+        match = MatchMode(raw["match"])
+    except ValueError:
+        raise LexiconError(
+            f"{where}: {raw['match']!r} is not a match mode. The modes are "
+            f"code and closed: {sorted(m.value for m in MatchMode)}"
+        ) from None
+    return Section(
+        match=match,
+        budget=int(raw["budget"]),
+        entries=_entries(raw["entries"], name, path),
     )
+
+
+def load_lexicon(path: Path, *, clitics: frozenset[str] = frozenset()) -> Lexicon:
+    data = load_yaml(path)
+    require_keys(data, {"schema_version", "sections"}, name=str(path))
     if data["schema_version"] != SCHEMA_VERSION:
         raise LexiconError(
             f"{path}: schema_version {data['schema_version']!r}, expected "
             f"{SCHEMA_VERSION}"
         )
-    sections = {
-        name: _section(data.get(name) or (), name, path)
-        for name in (*BUDGETS, "wasl_kasra")
-    }
-    for name, ceiling in BUDGETS.items():
-        size = len(sections[name])
-        if size > ceiling:
-            raise LexiconError(
-                f"{path}: {name} has {size} entries, over its budget of "
-                f"{ceiling}. A location table growing toward 10^4 is a signal "
-                f"that a rule is missing, not that the corpus is irregular."
-            )
-    return Lexicon(source=path, **sections)
+    sections = data["sections"] or {}
+    if not isinstance(sections, dict):
+        raise LexiconError(f"{path}: sections must be a mapping, got {sections!r}")
+    return Lexicon(
+        sections={
+            name: _section(raw, name, path) for name, raw in sections.items()
+        },
+        clitics=clitics,
+        source=path,
+    )
+
+
+def load_clitic_pronouns(path: Path) -> frozenset[str]:
+    """Arabic morphology, invariant across riwayat, so it is shared data."""
+    data = load_yaml(path)
+    require_keys(data, {"schema_version", "clitic_pronouns"}, name=str(path))
+    if data["schema_version"] != MORPHOLOGY_SCHEMA_VERSION:
+        raise LexiconError(
+            f"{path}: schema_version {data['schema_version']!r}, expected "
+            f"{MORPHOLOGY_SCHEMA_VERSION}"
+        )
+    return _entries(data["clitic_pronouns"], "clitic_pronouns", path)

--- a/quranic_phonemizer/data/riwayat/hafs/lexicon.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/lexicon.yaml
@@ -4,101 +4,136 @@
 # These replace a 575-skeleton table learned from Uthmani's own U+0671
 # positions. The three morphological rules in canon/derive/wasl.py do the
 # work; what remains is a handful of lexemes a grammarian names without
-# seeing this corpus. Entries are stems: the loader also matches a stem plus
-# any clitic pronoun, so `إيمان` covers `إيمانكم` and `إيمانهم` too.
+# seeing this corpus.
 #
-# A rise past the declared budget means a rule is
-# missing, not that the corpus is irregular.
-schema_version: 1
-
-# Hamza-initial particles that look prosthetic and are not.
-wasl_particles: ["ءن", "ءذ", "ءذن"]
-
-# Proper nouns, form-IV verbal nouns, and the ʾū- lexemes.
-wasl_exempt:
-  - "ءسرءل"      # إسرائيل
-  - "ءسمعل"      # إسماعيل
-  - "ءبرهم"      # إبراهيم
-  - "ءبلس"       # إبليس
-  - "ءسحق"       # إسحاق
-  - "ءمن"        # إيمان
-  - "ءحسن"       # إحسان
-  - "ءخون"       # إخوان
-  - "ءلون"       # ألوان
-  - "ءلسنت"      # ألسنة
-  - "ءلق"        # ألقى
-  - "ءحد"        # إحدى
-  - "ءخرج"       # إخراج
-  - "ءلت"        # سألت
-  - "ءت"         # أوتوا
-  - "ءل"         # أولو
-  - "ءثم"        # إثم
-  - "ءلحق"      # ألحق
-  - "ءتء"       # إيتاء
-  - "ءطعم"      # إطعام
-  - "ءليس"      # إلياس
-  # hamza + lām roots. These collide with the article and only a dictionary
-  # separates them, so they are listed. `is_wasl` consults the article first,
-  # which is what keeps a three-letter entry from swallowing the definite
-  # class — see the ordering note there.
-  - "ءلف"       # ألّف، ألف، ألفينا
-  - "ءلزم"      # ألزم
-  - "ءله"       # ألهم، ألهاكم
-  - "ءلوح"      # ألواح
-  - "ءلسن"      # ألسنة
-  - "ءلحف"      # إلحاف
-  - "ءلحد"      # إلحاد
-  - "ءلد"       # ألدّ
-  # nouns and form-IV verbs
-  - "ءخو"       # إخوة
-  - "ءخت"       # أخت
-  - "ءدرس"      # إدريس
-  - "ءفك"       # إفك
-  - "ءصر"       # إصر
-  - "ءعط"       # أعطى
-  - "ءد"        # إدّ
-  - "ءنتم"      # أنتم
-
-# Hamza + doubled lam, where the hamza is not prosthetic. Its own list: the
-# ambiguity here is `ألَّف` and `إلَّم` against `الَّذى` and `اللَّه`, which is
-# not the ambiguity `wasl_exempt` resolves, and the two collide on `ءلت`.
-wasl_exempt_doubled:
-  - "ءلف"       # ألّف
-  - "ءلم"       # إلّم
-  - "ءلن"       # ألّن
-
-# Kasra although the third letter carries damma, because that damma is not
-# the stem's. Two closed classes, one behaviour: the ten nouns, where the
-# damma is an inflectional ending, and the defective verbs of `يَمْشِى`,
-# `يَقْضِى`, `يَبْنِى` and `يَأْتِى`, where it belongs to the plural waw that
-# replaced their dropped final radical. `ٱدْعُوا۟` keeps its damma: `يَدْعُو`
-# has one of its own, and nothing in the rasm shows the difference.
-wasl_kasra: ["ءسم", "ءبن", "ءبنة", "ءمرء", "ءمرءة", "ءثنن", "ءثنتن", "ءست",
-             "ءمش", "ءقض", "ءءت", "ءءتن"]
-
-# The seven alifs: short in wasl, long at pause.
-# `لَٰكِنَّ` and `لَّـٰكِنَّا۠` share a key even with the vowels and the
-# gemination spelled, so the second is a Ledger entry rather than a
-# lexeme: one site, and no rule can reach it. `قَوَارِيرَا۠` is the same:
-# only the first of its three sites is pausal.
-pausal_lexemes: ["ءaنa", "سaلسaبiلa"]
-
-# Form VIII with lam as the first radical. After a wasl hamza these are shaped
-# exactly like the article before a sun letter -- ءلت... either way -- and the
-# article's gemination is an attestation rather than a canonical Onset, so no
-# rule can separate them from the Score. A closed grammatical class: three
-# roots, enumerable from a grammar by someone who has never seen this corpus.
+# Each section declares how its entries are matched and how large it may
+# grow. The modes are code -- a closed enum in canon/lexicon.py -- and mean:
 #
-# Matched whole, not as prefixes: التقوى extends التقى and is the article
-# before a sun letter, so each agreement suffix is its own entry.
+#   exact      the key, and nothing else
+#   clitic     the key, or a stem plus one clitic pronoun (data/shared/)
+#   inflected  clitic, or a stem of three letters or more as a prefix
+#   proclitic  the key, or the key after one proclitic
 #
-#   لقي  التقى، التقتا، التقيتم، التقطه، التقمه
-#   لمس  التمسوا
-#   لفف  التفت
-form_eight_lam: ["ءلتق", "ءلتقت", "ءلتقيتم", "ءلتقط", "ءلتقم", "ءلتمس",
-                 "ءلتفت"]
+# `budget` is a ceiling tests/test_lexicon.py enforces. A rise past it means
+# a rule is missing, not that the corpus is irregular, so it is a reviewable
+# failure rather than a package that will not import.
+schema_version: 2
 
-# What the name spells from its doubled lam onward, vocative included. The
-# heavy lam and the unwritten alif belong to this lexeme and to no other
-# word that opens ال + لـه: ٱللَّهْو and ٱللَّهَب carry a third radical.
-divine_name: ["له", "لهم"]
+sections:
+
+  # Hamza-initial particles that look prosthetic and are not.
+  wasl_particles:
+    match: inflected
+    budget: 10
+    entries: ["ءن", "ءذ", "ءذن"]
+
+  # Proper nouns, form-IV verbal nouns, and the ʾū- lexemes.
+  wasl_exempt:
+    match: inflected
+    budget: 60
+    entries:
+      - "ءسرءل"      # إسرائيل
+      - "ءسمعل"      # إسماعيل
+      - "ءبرهم"      # إبراهيم
+      - "ءبلس"       # إبليس
+      - "ءسحق"       # إسحاق
+      - "ءمن"        # إيمان
+      - "ءحسن"       # إحسان
+      - "ءخون"       # إخوان
+      - "ءلون"       # ألوان
+      - "ءلسنت"      # ألسنة
+      - "ءلق"        # ألقى
+      - "ءحد"        # إحدى
+      - "ءخرج"       # إخراج
+      - "ءلت"        # سألت
+      - "ءت"         # أوتوا
+      - "ءل"         # أولو
+      - "ءثم"        # إثم
+      - "ءلحق"      # ألحق
+      - "ءتء"       # إيتاء
+      - "ءطعم"      # إطعام
+      - "ءليس"      # إلياس
+      # hamza + lām roots. These collide with the article and only a
+      # dictionary separates them, so they are listed. `is_wasl` consults the
+      # article first, which is what keeps a three-letter entry from
+      # swallowing the definite class — see the ordering note there.
+      - "ءلف"       # ألّف، ألف، ألفينا
+      - "ءلزم"      # ألزم
+      - "ءله"       # ألهم، ألهاكم
+      - "ءلوح"      # ألواح
+      - "ءلسن"      # ألسنة
+      - "ءلحف"      # إلحاف
+      - "ءلحد"      # إلحاد
+      - "ءلد"       # ألدّ
+      # nouns and form-IV verbs
+      - "ءخو"       # إخوة
+      - "ءخت"       # أخت
+      - "ءدرس"      # إدريس
+      - "ءفك"       # إفك
+      - "ءصر"       # إصر
+      - "ءعط"       # أعطى
+      - "ءد"        # إدّ
+      - "ءنتم"      # أنتم
+
+  # Hamza + doubled lam, where the hamza is not prosthetic. Its own section:
+  # the ambiguity here is `ألَّف` and `إلَّم` against `الَّذى` and `اللَّه`,
+  # which is not the ambiguity `wasl_exempt` resolves, and the two collide on
+  # `ءلت`. `ءلف` is in both, for the two different questions.
+  wasl_exempt_doubled:
+    match: inflected
+    budget: 10
+    entries:
+      - "ءلف"       # ألّف
+      - "ءلم"       # إلّم
+      - "ءلن"       # ألّن
+
+  # Kasra although the third letter carries damma, because that damma is not
+  # the stem's. Two closed classes, one behaviour: the ten nouns, where the
+  # damma is an inflectional ending, and the defective verbs of `يَمْشِى`,
+  # `يَقْضِى`, `يَبْنِى` and `يَأْتِى`, where it belongs to the plural waw
+  # that replaced their dropped final radical. `ٱدْعُوا۟` keeps its damma:
+  # `يَدْعُو` has one of its own, and nothing in the rasm shows the
+  # difference.
+  wasl_kasra:
+    match: clitic
+    budget: 20
+    entries: ["ءسم", "ءبن", "ءبنة", "ءمرء", "ءمرءة", "ءثنن", "ءثنتن", "ءست",
+              "ءمش", "ءقض", "ءءت", "ءءتن"]
+
+  # The seven alifs: short in wasl, long at pause. Alone in being keyed on
+  # the vocalised notation rather than the bare skeleton, because the vowels
+  # are what tell them apart -- which is why one proclitic is two characters.
+  # `لَٰكِنَّ` and `لَّـٰكِنَّا۠` share a key even with the vowels and the
+  # gemination spelled, so the second is a Ledger entry rather than a
+  # lexeme: one site, and no rule can reach it. `قَوَارِيرَا۠` is the same:
+  # only the first of its three sites is pausal.
+  pausal_lexemes:
+    match: proclitic
+    budget: 10
+    entries: ["ءaنa", "سaلسaبiلa"]
+
+  # Form VIII with lam as the first radical. After a wasl hamza these are
+  # shaped exactly like the article before a sun letter -- ءلت... either way
+  # -- and the article's gemination is an attestation rather than a canonical
+  # Onset, so no rule can separate them from the Score. A closed grammatical
+  # class: three roots, enumerable from a grammar by someone who has never
+  # seen this corpus.
+  #
+  # Matched whole, not as prefixes: التقوى extends التقى and is the article
+  # before a sun letter, so each agreement suffix is its own entry.
+  #
+  #   لقي  التقى، التقتا، التقيتم، التقطه، التقمه
+  #   لمس  التمسوا
+  #   لفف  التفت
+  form_eight_lam:
+    match: clitic
+    budget: 10
+    entries: ["ءلتق", "ءلتقت", "ءلتقيتم", "ءلتقط", "ءلتقم", "ءلتمس", "ءلتفت"]
+
+  # What the name spells from its doubled lam onward, vocative included. The
+  # heavy lam and the unwritten alif belong to this lexeme and to no other
+  # word that opens ال + لـه: ٱللَّهْو and ٱللَّهَب carry a third radical.
+  divine_name:
+    match: exact
+    budget: 5
+    entries: ["له", "لهم"]

--- a/quranic_phonemizer/data/riwayat/hafs/scripts/indopak.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/scripts/indopak.yaml
@@ -36,11 +36,11 @@ letters:
   "ن": NOON
   "ه": HEH
   "ة": TAA_MARBUTA
-  "ا": ALIF
-  "و": WAW
-  "ي": {letter: YA, bare_rasm: true}   # IndoPak writes the maqsura plain
+  "ا": {letter: ALIF, seat: true}
+  "و": {letter: WAW, seat: true}
+  "ي": {letter: YA, bare_rasm: true, seat: true}   # IndoPak writes the maqsura plain
   # Drawn only as a hamza's seat or as rasm; a sounded yaa is `ي` above.
-  "ى": {letter: YA, bare_rasm: true, rasm_only: true}
+  "ى": {letter: YA, bare_rasm: true, rasm_only: true, seat: true}
   "ء": HAMZA
   "ٱ": {letter: HAMZA, onset: WASL}
 

--- a/quranic_phonemizer/data/riwayat/hafs/scripts/uthmani.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/scripts/uthmani.yaml
@@ -31,10 +31,10 @@ letters:
   "ن": NOON
   "ه": HEH
   "ة": TAA_MARBUTA
-  "ا": ALIF
-  "و": {letter: WAW, dagger_host: true}
-  "ي": YA
-  "ى": {letter: YA, dagger_host: true, bare_rasm: true}   # alif maqsura
+  "ا": {letter: ALIF, seat: true}
+  "و": {letter: WAW, dagger_host: true, seat: true}
+  "ي": {letter: YA, seat: true}
+  "ى": {letter: YA, dagger_host: true, bare_rasm: true, seat: true}   # alif maqsura
   "ء": HAMZA
   "أ": HAMZA
   "إ": HAMZA

--- a/quranic_phonemizer/data/shared/morphology.yaml
+++ b/quranic_phonemizer/data/shared/morphology.yaml
@@ -1,0 +1,12 @@
+# Arabic morphology, not one riwayah's reading of it. Shared for the same
+# reason the muqattaat letter names are: which pronouns attach to a word is a
+# fact about the language, and every riwayah recites the same language.
+#
+# Written in canonical letters, like every lexicon key.
+schema_version: 1
+
+# The attached pronouns. A closed class, so a lexicon entry can be a stem and
+# still cover its whole inflectional family: `ءمن` matches `إيمانكم` and
+# `إيمانهم` without either being listed.
+clitic_pronouns: ["ه", "هم", "هما", "هن", "ك", "كم", "كما", "كن", "نا", "ي",
+                  "ني", "همء"]

--- a/quranic_phonemizer/orthography/adapter.py
+++ b/quranic_phonemizer/orthography/adapter.py
@@ -54,6 +54,9 @@ class Cluster:
     """A letter of the reading the rasm leaves out, written small."""
     rasm_only: bool = False
     """The glyph never spells a sound of its own."""
+    seat: bool = False
+    """A hamza may be written on this base. A bare seat always may; which
+    letters also may is the script's to declare, not this package's."""
 
     def mark(self, role: str) -> Mark | None:
         for mark in self.marks:

--- a/quranic_phonemizer/orthography/cluster.py
+++ b/quranic_phonemizer/orthography/cluster.py
@@ -13,12 +13,6 @@ from .inventory import Inventory, InventoryError, LetterEntry, MarkEntry
 #: The small alif, which is a hamza's rest as readily as a seat is.
 DAGGER = "dagger"
 
-#: What a hamza may be written on. `None` is a bare seat; the three carriers
-#: spell no sound of their own when they hold one.
-SEATABLE = frozenset(
-    {None, CanonLetter.ALIF, CanonLetter.WAW, CanonLetter.YA}
-)
-
 
 def read_verse(
     inventory: Inventory,
@@ -87,6 +81,7 @@ class _ReadState:
             dagger_host=entry.dagger_host,
             bare_rasm=entry.bare_rasm,
             rasm_only=entry.rasm_only,
+            seat=entry.seat,
             marked_script=self.inventory.marks_what_it_sounds,
         )
         self.letter_index += 1
@@ -126,7 +121,7 @@ class _ReadState:
         self.clusters[index].marks.append(_mark_of(char, offset, entry))
 
         if char in self.inventory.combining_hamza:
-            if self.clusters[index].letter in SEATABLE:
+            if self.clusters[index].seat:
                 self._fold_to_hamza(index, offset)
             else:
                 self.clusters[index].marks.pop()
@@ -205,6 +200,7 @@ class _ReadState:
                 word=self.word_index,
                 index=self.letter_index,
                 dagger_host=True,
+                seat=True,
             )
         )
         index = len(self.clusters) - 1
@@ -225,6 +221,7 @@ class _ReadState:
         self.clusters[index].letter = CanonLetter.HAMZA
         self.clusters[index].dagger_host = False
         self.clusters[index].bare_rasm = False
+        self.clusters[index].seat = False
 
     def _grapheme(self, char: str, offset: int, cls: GraphemeClass) -> None:
         self.graphemes.append(

--- a/quranic_phonemizer/orthography/inventory.py
+++ b/quranic_phonemizer/orthography/inventory.py
@@ -66,6 +66,9 @@ class LetterEntry:
     rasm_only: bool = False
     """The glyph never spells a sound of its own. IndoPak draws the maqsura
     only as a hamza's seat or as rasm, and writes a sounded yaa as `ي`."""
+    seat: bool = False
+    """A combining hamza written here rests on the glyph rather than being a
+    letter of its own, so the cluster becomes the hamza: `ٮ` + `ٔ` is `ئ`."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -284,7 +287,7 @@ def _letter(spec: Any, *, where: str) -> LetterEntry:
         spec,
         {"letter"},
         name=where,
-        optional={"onset", "dagger_host", "bare_rasm", "rasm_only"},
+        optional={"onset", "dagger_host", "bare_rasm", "rasm_only", "seat"},
     )
     onset = spec.get("onset")
     return LetterEntry(
@@ -293,6 +296,7 @@ def _letter(spec: Any, *, where: str) -> LetterEntry:
         dagger_host=bool(spec.get("dagger_host", False)),
         bare_rasm=bool(spec.get("bare_rasm", False)),
         rasm_only=bool(spec.get("rasm_only", False)),
+        seat=bool(spec.get("seat", False)),
     )
 
 

--- a/quranic_phonemizer/orthography/inventory.py
+++ b/quranic_phonemizer/orthography/inventory.py
@@ -199,7 +199,7 @@ def load_inventory(
             f"{path}: {overlap} are declared both as letters and as marks; a "
             f"scalar resolves to exactly one classification"
         )
-    _check_contract(path, letters, marks, derivations, roles)
+    _check_contract(path, marks, derivations, roles)
     return Inventory(
         script=script,
         riwayah=riwayah,
@@ -242,23 +242,14 @@ def _check_identity(path, data, riwayah: Riwayah, script: Script) -> None:
         )
 
 
-def _check_contract(path, letters, marks, derivations, roles) -> None:
+def _check_contract(path, marks, derivations, roles) -> None:
     """Verify every named derivation and required role actually exists.
 
     `derivations` and `roles` are injected, not imported: `orthography` may
-    not depend on `canon`.
+    not depend on `canon`. Only a mark may name a derivation.
     """
+    named = {entry.derivation for entry in marks.values() if entry.derivation}
     if derivations is not None:
-        named = {
-            entry.derivation
-            for entry in marks.values()
-            if getattr(entry, "derivation", None)
-        }
-        named |= {
-            spec.derivation
-            for spec in letters.values()
-            if getattr(spec, "derivation", None)
-        }
         unknown = sorted(named - derivations)
         if unknown:
             raise InventoryError(

--- a/quranic_phonemizer/riwayat/hafs/resources.py
+++ b/quranic_phonemizer/riwayat/hafs/resources.py
@@ -13,7 +13,7 @@ from ...canon import derive
 from ...canon.ledger import EMPTY as EMPTY_LEDGER
 from ...canon.ledger import Ledger, load_ledger
 from ...canon.lexicon import EMPTY as EMPTY_LEXICON
-from ...canon.lexicon import Lexicon, load_lexicon
+from ...canon.lexicon import Lexicon, load_clitic_pronouns, load_lexicon
 from ...canon.spell import Muqattaat, load_muqattaat
 from ...corpus import PackedCorpus, load_corpus
 from ...model.address import Location, Riwayah, Script, VerseRef
@@ -80,8 +80,13 @@ def ledger() -> Ledger:
 
 
 def lexicon() -> Lexicon:
+    """The clitic pronouns are shared: which pronouns attach to a word is a
+    fact about Arabic, not about how this riwayah recites it."""
     path = DATA / "lexicon.yaml"
-    return load_lexicon(path) if path.exists() else EMPTY_LEXICON
+    if not path.exists():
+        return EMPTY_LEXICON
+    clitics = load_clitic_pronouns(DATA.parents[1] / "shared" / "morphology.yaml")
+    return load_lexicon(path, clitics=clitics)
 
 
 def rule_tables() -> RuleTables:

--- a/tests/test_inventory_contract.py
+++ b/tests/test_inventory_contract.py
@@ -10,9 +10,15 @@ from pathlib import Path
 import pytest
 
 from quranic_phonemizer.canon import derive
-from quranic_phonemizer.model.address import Script
+from quranic_phonemizer.model.address import Location, Script, VerseRef
+from quranic_phonemizer.model.canon import CanonLetter
+from quranic_phonemizer.orthography.cluster import read_verse
 from quranic_phonemizer.orthography.inventory import InventoryError, load_inventory
 from quranic_phonemizer.riwayat.hafs.resources import DATA, RIWAYAH, SCRIPTS
+
+#: IndoPak spells `ئ` as a yaa carrying a combining hamza, so the yaa is the
+#: shortest word in either script that reaches the seat branch.
+SEATED_HAMZA = "ئ"
 
 CONTRACT = {
     "riwayah": RIWAYAH,
@@ -74,6 +80,39 @@ def test_a_script_specific_role_is_not_required_of_every_script(tmp_path):
     assert "cross_word_noon" not in read.get("carrier", frozenset())
     _load(tmp_path, _inventory_text(Script.UTHMANI))
     _load(tmp_path, _inventory_text(Script.INDOPAK), Script.INDOPAK)
+
+
+def _first_letter(inventory, text: str) -> CanonLetter | None:
+    reading = read_verse(
+        inventory, VerseRef(1, 1), ((Location(1, 1, 1), text),)
+    )
+    return reading.clusters[0].letter
+
+
+def test_a_hamza_written_on_a_seat_becomes_the_hamza(tmp_path):
+    """The behaviour `SEATABLE` used to carry, now read off the script."""
+    inventory = _load(tmp_path, _inventory_text(Script.INDOPAK), Script.INDOPAK)
+    assert _first_letter(inventory, SEATED_HAMZA) is CanonLetter.HAMZA
+
+
+def test_a_scalar_the_script_does_not_call_a_seat_does_not_fold(tmp_path):
+    """Falsifier: without the flag being read, every carrier is seatable
+    again and the script has no say -- which is what put four Hafs glyphs in
+    a Python frozenset to begin with."""
+    text = _inventory_text(Script.INDOPAK).replace(
+        '"ي": {letter: YA, bare_rasm: true, seat: true}',
+        '"ي": {letter: YA, bare_rasm: true}',
+    )
+    inventory = _load(tmp_path, text, Script.INDOPAK)
+    assert _first_letter(inventory, SEATED_HAMZA) is not CanonLetter.HAMZA
+
+
+def test_an_unknown_capability_is_a_load_error(tmp_path):
+    """A capability the loader does not know is a misspelling, and a
+    misspelled flag that parses is a capability silently switched off."""
+    text = _inventory_text(Script.INDOPAK).replace("seat: true", "seet: true", 1)
+    with pytest.raises(ValueError, match="seet"):
+        _load(tmp_path, text, Script.INDOPAK)
 
 
 def test_the_registry_is_complete_without_importing_the_builder():

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -1,0 +1,149 @@
+"""The lexicon: its sections are data, and its budgets are this gate.
+
+The ceiling used to be raised from `load_lexicon`, so a breach was a package
+that would not import. Here it is a red test with the numbers in the message.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quranic_phonemizer.canon.lexicon import (
+    EMPTY,
+    MatchMode,
+    LexiconError,
+    load_clitic_pronouns,
+    load_lexicon,
+)
+from quranic_phonemizer.riwayat.hafs.resources import DATA
+
+SHARED = DATA.parents[1] / "shared"
+
+
+@pytest.fixture(scope="module")
+def lexicon():
+    return load_lexicon(
+        DATA / "lexicon.yaml",
+        clitics=load_clitic_pronouns(SHARED / "morphology.yaml"),
+    )
+
+
+def _text(name: str = "lexicon.yaml") -> str:
+    root = SHARED if name == "morphology.yaml" else DATA
+    return (root / name).read_text(encoding="utf-8")
+
+
+def _load(tmp_path: Path, text: str):
+    path = tmp_path / "lexicon.yaml"
+    path.write_text(text, encoding="utf-8")
+    return load_lexicon(path, clitics=frozenset({"هم"}))
+
+
+# -- the budget -----------------------------------------------------------
+def test_no_section_is_over_its_budget(lexicon):
+    """A rise past a ceiling means a rule is missing, not that the corpus is
+    irregular. Reviewable here; it used to break the import instead."""
+    over = {
+        name: (len(section.entries), section.budget)
+        for name, section in lexicon.sections.items()
+        if len(section.entries) > section.budget
+    }
+    assert not over, f"sections over budget (size, ceiling): {over}"
+
+
+def test_every_section_declares_a_budget(lexicon):
+    """Falsifier: `wasl_kasra` had no ceiling and was spliced past the table
+    that held them, so the one section nobody bounded was invisible."""
+    assert lexicon.sections
+    assert all(section.budget > 0 for section in lexicon.sections.values())
+
+
+# -- the four match modes -------------------------------------------------
+def test_exact_takes_the_key_and_nothing_else(lexicon):
+    assert lexicon.is_divine_name("له")
+    assert not lexicon.is_divine_name("لهو")
+
+
+def test_clitic_takes_a_stem_plus_one_attached_pronoun(lexicon):
+    assert lexicon.is_form_eight_lam("ءلتقط")
+    assert lexicon.is_form_eight_lam("ءلتقطه")
+    assert not lexicon.is_form_eight_lam("ءلتقطون")
+
+
+def test_inflected_also_takes_a_stem_of_three_as_a_prefix(lexicon):
+    assert lexicon.is_wasl_exempt("ءمن")
+    assert lexicon.is_wasl_exempt("ءمنكم")
+    assert lexicon.is_wasl_exempt("ءمنهم")
+
+
+def test_a_stem_under_three_letters_is_not_a_prefix(lexicon):
+    """`ءل` is an entry, and matching it as a prefix would swallow the whole
+    definite article. Length is what keeps a short entry specific."""
+    assert lexicon.is_wasl_exempt("ءل")
+    assert not lexicon.is_wasl_exempt("ءلكتب")
+
+
+def test_proclitic_takes_the_key_after_exactly_one_proclitic(lexicon):
+    assert lexicon.is_pausal("ءaنa")
+    assert lexicon.is_pausal("وaءaنa")
+    assert not lexicon.is_pausal("وaلaءaنa")
+
+
+def test_a_lexicon_with_no_sections_answers_no_to_everything():
+    assert not EMPTY.is_divine_name("له")
+    assert not EMPTY.is_wasl_exempt("ءمن")
+    assert not EMPTY.pausal_lexemes
+
+
+# -- what the file must say about itself ----------------------------------
+def test_an_unknown_match_mode_is_a_load_error(tmp_path):
+    """The sections are data and the modes are code: a mode the resolver has
+    no branch for must not load as one it does."""
+    text = _text().replace("match: exact", "match: roughly", 1)
+    with pytest.raises(LexiconError, match="not a match mode"):
+        _load(tmp_path, text)
+
+
+def test_a_section_missing_its_budget_is_a_load_error(tmp_path):
+    text = _text().replace("    budget: 5\n", "", 1)
+    assert text != _text()
+    with pytest.raises(ValueError, match="budget"):
+        _load(tmp_path, text)
+
+
+def test_a_repeated_entry_is_a_load_error(tmp_path):
+    """A set would swallow it before the budget counts it, so the file would
+    show more rows than the ceiling ever sees."""
+    text = _text().replace('entries: ["له", "لهم"]', 'entries: ["له", "له"]')
+    with pytest.raises(LexiconError, match="twice"):
+        _load(tmp_path, text)
+
+
+def test_the_schema_version_is_checked(tmp_path):
+    with pytest.raises(LexiconError, match="schema_version"):
+        _load(tmp_path, _text().replace("schema_version: 2", "schema_version: 1"))
+
+
+def test_every_declared_mode_is_one_the_resolver_has(lexicon):
+    """Falsifier for the enum being closed: a mode with no matcher would
+    resolve to no match rather than to an error."""
+    assert {s.match for s in lexicon.sections.values()} <= set(MatchMode)
+
+
+# -- the shared half ------------------------------------------------------
+def test_the_clitic_pronouns_are_shared_not_this_riwayah_s(lexicon):
+    """Which pronouns attach to a word is a fact about Arabic. Under `hafs/`
+    it would assert something false about every other riwayah."""
+    assert (SHARED / "morphology.yaml").exists()
+    assert not (DATA / "morphology.yaml").exists()
+    assert lexicon.clitics
+
+
+def test_a_repeated_clitic_pronoun_is_a_load_error(tmp_path):
+    path = tmp_path / "morphology.yaml"
+    path.write_text(
+        _text("morphology.yaml").replace('"ه", "هم"', '"ه", "ه"'), encoding="utf-8"
+    )
+    with pytest.raises(LexiconError, match="twice"):
+        load_clitic_pronouns(path)

--- a/tools/structure_lint.py
+++ b/tools/structure_lint.py
@@ -54,6 +54,9 @@ PUBLIC_API = frozenset({"Option", "VariantSelection", "KhilafId"})
 #: Imports whose only purpose is the side effect of importing them.
 SIDE_EFFECT = frozenset({"annotations"})
 
+#: Roles the inventory loader supplies rather than any file naming them.
+LOADER_ROLES = frozenset({"seat", "structural", "advice"})
+
 MAX_FILE_LINES = 400
 MAX_FUNCTION_LINES = 50
 
@@ -304,9 +307,115 @@ def phoneme_strings() -> list[Problem]:
     return out
 
 
+def _role_sites(tree: ast.Module) -> Iterator[ast.expr]:
+    """Every expression this module hands to a role lookup."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("has", "mark")
+        ):
+            yield from node.args
+        elif isinstance(node, ast.Compare) and _names_role(node.left):
+            yield from node.comparators
+
+
+def _role_holders(trees: list[ast.Module]) -> set[str]:
+    """Names the package uses where a role is expected.
+
+    A constant holding a role is the third shape, after a bare literal and a
+    set splatted into `has`. `DAGGER` and `CROSS_WORD_ROLE` are both this.
+    """
+    out: set[str] = set()
+    for tree in trees:
+        for site in _role_sites(tree):
+            node = site.value if isinstance(site, ast.Starred) else site
+            if isinstance(node, ast.Name):
+                out.add(node.id)
+            elif isinstance(node, ast.Attribute):
+                out.add(node.attr)
+    return out
+
+
+def _role_literals(tree: ast.Module, holders: set[str]) -> Iterator[tuple[int, str]]:
+    """Strings this module uses as an inventory role."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id in holders for t in node.targets
+        ):
+            yield from _strings(ast.walk(node.value), node.lineno)
+    for site in _role_sites(tree):
+        yield from _strings([site], site.lineno)
+
+
+def _names_role(node: ast.expr) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "role"
+
+
+def _strings(nodes, line: int) -> Iterator[tuple[int, str]]:
+    for node in nodes:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield line, node.value
+
+
+def _declared_roles() -> set[str]:
+    """Every role a derivation says it reads or an inventory says it writes."""
+    import yaml
+
+    out: set[str] = set()
+    for _, tree in _modules():
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and _is_register(node.func)):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "requires":
+                    out |= {
+                        role for _, role in _strings(ast.walk(keyword.value), 0)
+                    }
+    for path in sorted((PACKAGE / "data").rglob("scripts/*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for section in ("evidences", "decorates", "advice", "structural"):
+            entries = data.get(section) or {}
+            # An entry that names no role is keyed by the scalar it is
+            # written with, and the loader uses that as the role.
+            out |= set(entries)
+            if isinstance(entries, dict):
+                out |= {
+                    str(spec["role"])
+                    for spec in entries.values()
+                    if isinstance(spec, dict) and "role" in spec
+                }
+    return out
+
+
+def _is_register(func: ast.expr) -> bool:
+    return (isinstance(func, ast.Name) and func.id == "register") or (
+        isinstance(func, ast.Attribute) and func.attr == "register"
+    )
+
+
+def role_vocabulary() -> list[Problem]:
+    """A role name in code that no derivation and no inventory declares.
+
+    `Cluster.has` answers `False` for an unknown role rather than raising, so
+    without this a one-character slip is a silent output change.
+    """
+    declared = _declared_roles() | LOADER_ROLES
+    modules = list(_modules())
+    holders = _role_holders([tree for _, tree in modules])
+    out: list[Problem] = []
+    for path, tree in modules:
+        for line, role in sorted(set(_role_literals(tree, holders))):
+            if role not in declared:
+                out.append((path, line, "role-vocabulary",
+                            f"{role!r} is a role nothing declares"))
+    return out
+
+
 CHECKS = {
     "import-graph": import_graph,
     "unused-imports": unused_imports,
+    "role-vocabulary": role_vocabulary,
     "module-size": module_size,
     "dead-exports": dead_exports,
     "phoneme-strings": phoneme_strings,


### PR DESCRIPTION
The Warsh-agnostic half of design questions 01 and 04 — everything that does not need the inventory schema decided first. Then 01, 04 and 07 become one document, because they were asking one question.

Five findings that read as five chores. They are one shape: a Python constant restating something a data file already says, or enforcing a data rule from the wrong place.

| constant | what it restated | now |
|---|---|---|
| `cluster.SEATABLE` | which glyphs of Hafs a hamza may rest on | a `seat:` capability per scalar |
| role literals | inventory role names, 14 of them | a `role-vocabulary` check |
| `lexicon.CLITIC_PRONOUNS` | Arabic's attached pronouns | `data/shared/morphology.yaml` |
| `lexicon.BUDGETS` | a ceiling per lexicon section | `budget:`, checked by a test |
| lexicon section names | the sections of `lexicon.yaml` | one `sections:` mapping |

## Which glyphs a hamza may rest on (`bbc40a7`)

A frozenset of four Hafs glyphs in Python, consulted once, deciding whether a combining hamza folds into the base or becomes a letter of its own. The inventory already carries this kind of fact — `onset`, `dagger_host`, `bare_rasm`, `rasm_only` — so a seat travels the same route. A bare seat sets it by construction; folding to a hamza clears it, as it already cleared the two sibling flags.

The frozenset could not be wrong about Hafs. It could not be right about Warsh either, and nothing would have said so.

## A role named in code is a role something declares (`6409f2d`)

`register(requires=...)` exists because `Cluster.has` answers `False` for an unknown role rather than raising — its own docstring says so. Nothing checked the code against it, so the guard ran one way only: a misspelling in a script YAML failed at load, a misspelling in Python silently changed output.

`structure_lint` gains `role-vocabulary`: every string the package hands to a role lookup — a literal argument to `has`/`mark`, a set splatted into one, a comparison against `.role`, and the constants holding those — must be a role some derivation declares or some inventory writes. Fourteen literals, all declared, zero problems.

**Not a per-derivation subset check, which would have been a lie.** `requires` is a hand-kept proxy, not a description:

- `hamzat_wasl` declares 13 roles; its body is `del context; return Sets(...)` and reads none. The 13 belong to `wasl.is_wasl`, which `canon.build` calls directly, never via `resolve()`.
- `pausal_length` declares 9 and reads none. `carrier` declares 10, reads one.
- Five `has()` sites in `derive/lexeme.py` are in no registered derivation at all. They pass only because `ALWAYS_RUN` drags in `carrier`'s over-broad set — tightening `carrier` to what it reads would leave them undeclared and silent.

Making `requires` true is worth doing and is in 08, not here: `cross_word_noon` declares nothing deliberately, because requiring IndoPak's convention would reject Uthmani for not writing something Uthmani does not write.

Two defects in the contract check it complements, same subsystem: `_check_contract` read `named` outside the block binding it, so `derivations=None` raised `UnboundLocalError` rather than `InventoryError`; and it scanned letters for a `derivation` field `LetterEntry` has not got and `require_keys` forbids.

## The lexicon says what its sections are (`01f3ff9`)

Each section was named three times — in `BUDGETS`, which doubled as the section registry, as a dataclass field, and in a method. `wasl_kasra` had no budget and was spliced past that table by hand at both of its uses: the one section nobody bounded was the one the mechanism could not see.

Now `sections:`, each declaring `match`, `budget` and `entries`. `MatchMode` is a closed enum in source — the modes are code, the sections are data. The four are what the helpers already did, named rather than inferred from which helper a method called.

`budget:` is enforced by `tests/test_lexicon.py` instead of raised from `load_lexicon`. A breach was a package that would not import; it is now a red test naming the section, its size and its ceiling.

The clitic pronouns move to `data/shared/morphology.yaml`. Which pronouns attach to a word is a fact about Arabic; under `hafs/` it would assert something false. That was also the last Arabic string in package code outside the canonical alphabet.

**No entry is added, removed or edited.** The duplicate the audit found — `ءلف` in both `wasl_exempt` and `wasl_exempt_doubled` — is untouched and the file now says the overlap is deliberate. Whether it should be is a correctness question, not a schema one.

Adding a section drops from three source edits to one. Not the zero 04 asked for, and the ADR says why: a generic `matches("name", key)` would put back the string API the same audit wants removed.

## ADR-010, and 08 (`e5ab9d5`)

01, 04 and 07 each stalled at the same place — **does a script fact attach to a scalar, or to a match?** — so 08 asks it once and carries the rest forward: 07 whole, 01's shapes A and B with the census restated to what is in the tree now, 04's `rules.yaml` inheritance with the research it waits on. The originals move to `docs/archive/design/`, each headed with which half went where.

Two items leave the list rather than move to 08:

- **`schema_version` is per file.** `render/ipa.yaml` went to 2 in #44 and no other loader had to move; `lexicon.yaml` goes to 2 here and the other six stay at 1. That is the evidence 04 wanted, and it argues against one package-wide version.
- **`comment_lint`'s 84 ungrouped comment blocks** are a tooling chore, not a design question. Recorded in the ADR so the backlog is not lost.

`docs/design/README.md` gains a third exit: a document could previously only leave by becoming an ADR or being closed as no change.

## Noted, not fixed

- `cluster.py` `_fold_to_hamza` clears `dagger_host`, `bare_rasm` and now `seat`, but not `rasm_only`. Latent — `length.py` short-circuits on `HAMZA` first.
- `cluster.py` `_seat` omits `marked_script`, unlike `_letter` and `_omitted_letter`. Latent — both readers also require a non-`None` letter.
- `derive/wasl.py` and `derive/length.py` both define `VOWEL_ROLES`, with different values, in sibling modules.
- `SCRIPT_OPTIONAL`'s `small_waw`/`small_ya` are inert: no `requires` names either, so the subtraction never reaches them.
- `docs/README.md` still links to `docs/mualem_conversion.md`, and `docs/hafs/silent-letter-audit.md` to `tokenization-reconciliation.md`. Neither exists; both predate this branch. Every other link under `docs/` resolves.

## Falsifiers

Each run by hand, each failed as it should, each reverted:

- a role misspelled in Python is named by `role-vocabulary` at its line;
- a role name changed in a constant is caught the same way;
- a scalar whose script does not call it a seat stops folding a combining hamza;
- a section over its ceiling fails `tests/test_lexicon.py` with both numbers.

## Gates

No output moves. Every floor reads exactly as it did on the base commit.

| gate | result |
|---|---|
| suite | 267 passed, 1 skipped (was 249) |
| comment_lint | 0 problems in 90 files |
| structure_lint | 0 problems in 63 files |
| cross word / verse | 99.997% / 100.000% |
| regression word / verse | 99.928% / 97.674% |
| roundtrip uthmani | 100.000% |
| attest uthmani / indopak | 178 / 239 |
| l1 | 18 |

The lexicon had no tests at all before this. It has fifteen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw1ZYF3P8DTd2N5vjSUN7i)_