### PR TITLE
Where a slot is, which draft an edge means, and what a signature leaves unsaid

### DIFF
--- a/docs/adr/011-where-a-slot-is.md
+++ b/docs/adr/011-where-a-slot-is.md
@@ -1,0 +1,113 @@
+# ADR-011: Where a slot is, and which draft an edge means
+
+Status: **accepted**. Closes three of the four items in design question 05.
+Audit: "Abstraction".
+
+## Context
+
+`canon.build` and `rules/` had no agreed vocabulary for where a slot is, so
+each caller invented one. Three of the four consequences the design question
+listed had a single correct answer once measured; the fourth is still a
+judgement call and stays open.
+
+**Three implementations of "the slot before this one."** `boundary._previous`,
+`madd._before` and `tafkheem._before` were the same algorithm — rebuild the
+flat slot list with `Score.slots()`, scan it for the id, take the index
+before. `engine/neighbourhood.py` already held that list, an index into it,
+and the forward question `after()`. The cost was measurable but is not the
+argument: three copies of one question can disagree about a word boundary,
+and one of them would be wrong for a whole class of verses with no test
+noticing.
+
+**A pass list arriving by default.** `build(reading, passes=None)` fell back
+to `canon.passes.LEXEME_PASSES`, so a riwayah that forgot to supply its own
+got a working pipeline that was not its own.
+
+**`Scribe` keying on `id()`.** Grapheme-to-slot edges were recorded against
+`id()` of a mutable draft. A pass that dropped a draft took the key out of
+`ordinals` with it, `_slot` returned `None`, and the edge was discarded in
+silence. Measured over the corpus, both scripts: **1,283,790 edge lookups,
+188 misses, in 30 verses** — every one a muqattaat opening, where
+`canon/spell.py` replaces a word's drafts with the spelled letter names.
+They were harmless only because that pass re-evidences what it splices in, so
+the loss and the replacement cancelled. A written character anchored to no
+sound is invisible in output and invisible to the attestation gate, which by
+construction reads the links that survived.
+
+## Decision
+
+**One question, one implementation, on the object that already has the
+index.** `before`, `first_of_word` and `last_of_word` join `after` on
+`Neighbourhood`. The design question asked whether adjacency belongs there or
+on `Score`; `Neighbourhood` wins both halves because it holds the flat order
+and the word map, and answering from one index is what makes the answers
+agree by construction rather than by review.
+
+**No pass list arrives by default.** `passes` is required. There is no
+`BuildProfile`: it is still the only per-riwayah build knob, so there is
+nothing for one to carry. `LEXEME_PASSES` stays what it is — the shared two
+that `riwayat.hafs` composes its list from — rather than a default.
+
+**A draft has an identity, and losing an edge raises.** `_Draft` carries a
+`uid` minted at creation; `assemble` keys ordinals on it; a miss is
+`OrphanedEdgeError` naming the verse, the offset and the draft. A pass that
+drops a draft now has to say what becomes of its edges: `spell_muqattaat`
+calls `Scribe.withdraw(span)` rather than orphaning them.
+
+### Why `before` ignores junctions when `after` blocks at them
+
+`Neighbourhood.after()` returns `None` across a stop, because recitation ends
+there and a rule that cannot be heard across a pause must not fire across it.
+`before()` does not, because the slot behind a stop *was* said. That is what
+all three deleted copies did, so this ADR preserves behaviour rather than
+choosing it.
+
+It is recorded here because it was written down nowhere, and because **no
+gate distinguishes the two readings**. Making `before` block at junctions
+leaves all eight gates and every other test passing. One test in
+`tests/test_neighbourhood.py` is the only thing holding it, which is the
+whole reason that test exists.
+
+### Why an identity rather than an ordinal
+
+The obvious identity is the slot ordinal, and it is wrong: ordinals are
+assigned in `assemble` from the surviving draft list, so they do not exist
+while the passes that reorder, splice and drop drafts are running. A counter
+minted at draft creation survives all three.
+
+Two defects fall out of the same field. `list.remove` and `list.index`
+compare `_Draft` by value, so `spell.py`'s splice could have landed at an
+identical draft in an earlier word; and a freed `id()` can be reused by a
+draft created later in the same build, which would point an edge at the wrong
+slot rather than at none. Neither was firing — reuse measured zero across the
+corpus — and a unique field closes both.
+
+## What this does not decide
+
+**The five-object pass signature** stays open in design question 05. A
+`LexemePass` takes `(reading, drafts, lexicon, scribe, selection)` whether it
+needs all five or not, and 27 `del` statements say "accepted and deliberately
+ignored". `del` is honest — it makes the unused parameter visible where a
+linter suppression would hide it — so this is a signature that grew by
+addition, not a bug, and collapsing it into a context object trades the 27
+lines for invisible dependencies. Genuinely two-sided, and nothing forces it.
+
+**`cross_word_noon` returning a role name** rather than the slot it created
+is listed under 05 but belongs to design question 08:
+`build._split_tanween_words` greps the role name, so a script fact decides a
+canonical question, and the fix is bound up with making `requires` a
+description.
+
+## Evidence
+
+No output moves, and this time the stronger claim is available: the
+`Inscription` is byte-identical across the whole corpus in both scripts —
+**1,322,678 spellings, same digest** before and after. All eight gates read
+as they did: cross 99.997/100.000, regression 99.928/97.674, roundtrip
+100.000, attest 178/239, l1 18.
+
+Two falsifiers were run by hand and each failed as it should. Removing
+`Scribe.withdraw` from the muqattaat pass makes `2:1` raise
+`OrphanedEdgeError` at offset 0 — the path that used to swallow 188 edges.
+Making `before` block at junctions passes every gate, which is the finding
+that put a test around it.

--- a/docs/adr/011-where-a-slot-is.md
+++ b/docs/adr/011-where-a-slot-is.md
@@ -92,6 +92,11 @@ linter suppression would hide it — so this is a signature that grew by
 addition, not a bug, and collapsing it into a context object trades the 27
 lines for invisible dependencies. Genuinely two-sided, and nothing forces it.
 
+> Since closed by [ADR-012](012-what-a-signature-may-leave-unsaid.md).
+> Counting them was the measurement this paragraph assumed did not exist: the
+> 27 were three unrelated signatures plus five dead parameters, and only four
+> were `LexemePass`.
+
 **`cross_word_noon` returning a role name** rather than the slot it created
 is listed under 05 but belongs to design question 08:
 `build._split_tanween_words` greps the role name, so a script fact decides a

--- a/docs/adr/012-what-a-signature-may-leave-unsaid.md
+++ b/docs/adr/012-what-a-signature-may-leave-unsaid.md
@@ -1,0 +1,98 @@
+# ADR-012: What a signature may leave unsaid
+
+Status: **accepted**. Closes the last item of design question 05.
+Audit: "Abstraction".
+
+## Context
+
+Design question 05 asked whether the pass signature's 27 `del` statements
+were worth their explicitness, or should collapse into a context object. It
+sat open longest because it looked like the one item with no measurement that
+would settle it -- only a preference about what a signature should show.
+
+Counting them settles it. **The 27 were never one number.** They span three
+unrelated callback signatures plus five parameters that belong to no
+signature at all, and only four were the `LexemePass` the question named:
+
+| | signature | count | where |
+|---|---|---|---|
+| A | `Classifier.look(near, plan, at, boundaries)` -- *four* | 16 | `rules/` ×7 modules |
+| B | `LexemePass(reading, drafts, lexicon, scribe, selection)` | 4 | `canon/passes.py` ×2, `spell.py`, `khilaf.py` |
+| C | `derivation(context)` | 2 | `derive/length.py`, `derive/wasl.py` |
+| D | no protocol at all | 5 | `engine/run.py` ×2, `laws.py`, `derive/lexeme.py`, `rules/boundary.py` |
+
+Group D was dead code rather than a trade-off. `perform` built
+`index = {slot.id: slot for slot in slots}` for the sole purpose of handing it
+to `_materialise`, which deleted it. `relengthened(nucleus)` ignored its only
+argument and returned `Long(Quality.A)` unconditionally, so a call shaped like
+a transform transformed nothing.
+
+And the real defect was neither the count nor the collapse: the convention the
+`del`s serve **was not being applied**. `_apply_allah_lexeme` ignored
+`selection` and `_apply_pausal_lexemes` ignored `scribe` and `selection`,
+none of them saying so. Two of the five lexeme passes, silently. So "no `del`"
+meant either "reads all of them" or "the author forgot", with nothing to tell
+them apart -- there is no ruff and no mypy in this repository, and neither
+`comment_lint` nor `structure_lint` looked at a signature.
+
+## Decision
+
+**`del` stays, and becomes a checked claim rather than a convention.**
+`structure_lint`'s `signature-honesty` reports any protocol parameter a body
+neither reads nor deletes. 25 implementations are checked; a Protocol's own
+`...` body is skipped, since it declares parameters and by construction reads
+none.
+
+**Group D is deleted.** Five parameters and one dict comprehension that fed
+nothing. `relengthened` becomes the frozen value it always returned.
+
+**The two protocols state what they are.** `LexemePass` was
+`Callable[[Reading, list, object, object, object], None]` -- three `object`s
+type-check nothing, which is most of why the signature read as arbitrary. It
+is a `Protocol` with names and types. The `=None` defaults on three
+implementations went with it: `build` supplies all five on every call, so a
+default advertised an optionality no caller has.
+
+The count settles at **23**: 16 classifier, 5 pass, 2 derivation. Every one of
+them verified.
+
+### Why not a context object
+
+It would hide what a pass depends on, which is the thing the `del`s make
+visible. The recount sharpens this rather than softening it: 16 of the 23 are
+a *four*-parameter protocol where a context object buys one line per
+implementation and costs the dependency list. The remaining 5 are a
+five-parameter protocol whose fourth and fifth arguments -- the scribe and the
+variant selection -- are exactly the ones a reader needs to see a pass decline.
+
+### Why not `_plan` and `_boundaries`
+
+The underscore prefix is the standard idiom and would remove all 23 lines. It
+loses two things. `del` takes the name out of scope, so an edit that starts
+reading the parameter fails loudly; `_plan` can simply be read under its new
+name and nothing notices. And a `Protocol` declares parameter names, so an
+implementation that renames one stops matching it -- inert today with no type
+checker in CI, and a trap the moment one is added.
+
+## What this does not decide
+
+**Group C's two `del context`s** stay where they are. `hamzat_wasl` declares
+13 `requires` and reads zero; `pausal_length` declares 9 and reads zero. That
+is design question 08's question -- ADR-010 already records why `requires` is
+a hand-kept proxy and why a per-derivation check would be a lie -- and the
+`del` is a symptom of it, not the thing to fix.
+
+## Evidence
+
+No output moves. Every change either removes a parameter nothing read or adds
+a `del` for one nothing read. All eight gates read as they did: cross
+99.997/100.000, regression 99.928/97.674, roundtrip 100.000, attest 178/239,
+l1 18.
+
+Three falsifiers were run by hand and each failed as it should. Dropping
+`scribe` from `connect_plural_meem`'s `del` line is named at
+`passes.py:174`. Restoring the two defects this ADR's second commit fixed is
+named three times, once per silently ignored parameter -- so the check catches
+the exact defect that was live. And `_materialise` still raises
+`MaterialisationError` on a half-merge with `index` gone, which is the only
+behaviour the group D deletions came near.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ Read in order. 001–006 are the design; 007 is how it is laid out in code;
 | [008](008-conformance-and-phases.md) | Invariants, fixtures, the L1 harness, the reversal trigger, phase order |
 | [009](009-the-output-alphabet.md) | The output alphabet as entries plus composition, and what replaced row-count totality |
 | [010](010-constants-that-restate-data.md) | A constant that restates a data file becomes the data, or a check against it |
+| [011](011-where-a-slot-is.md) | Adjacency on `Neighbourhood`, a required pass list, and a draft identity that survives being dropped |
 
 ## What this is for
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Read in order. 001–006 are the design; 007 is how it is laid out in code;
 | [009](009-the-output-alphabet.md) | The output alphabet as entries plus composition, and what replaced row-count totality |
 | [010](010-constants-that-restate-data.md) | A constant that restates a data file becomes the data, or a check against it |
 | [011](011-where-a-slot-is.md) | Adjacency on `Neighbourhood`, a required pass list, and a draft identity that survives being dropped |
+| [012](012-what-a-signature-may-leave-unsaid.md) | `del` for a parameter a protocol forces, checked rather than conventional |
 
 ## What this is for
 

--- a/docs/archive/design/05-build-internals.md
+++ b/docs/archive/design/05-build-internals.md
@@ -1,10 +1,15 @@
 # 05 - The five-object pass signature
 
-Status: **open**, lowest urgency, and the last item of what was a four-part
-document. Audit: "Abstraction". The other three parts are
-[ADR-011](../adr/011-where-a-slot-is.md).
+> **Closed.** Three of this document's four items became
+> [ADR-011](../../adr/011-where-a-slot-is.md); the fourth, below, became
+> [ADR-012](../../adr/012-what-a-signature-may-leave-unsaid.md). Counting the
+> `del`s settled what this document assumed could only be a preference: the 27
+> were three unrelated signatures plus five parameters belonging to none, and
+> the defect was that the convention went unapplied, not that it cost lines.
 
-## What is left
+Status: **closed**. Audit: "Abstraction".
+
+## What was left
 
 A `LexemePass` takes `(reading, drafts, lexicon, scribe, selection)` whether
 it needs all five or not. 27 `del` statements across the package exist to say
@@ -18,6 +23,13 @@ pass's true dependencies invisible, which is the thing the `del`s currently
 make visible.
 
 Open, and genuinely two-sided: is the explicitness worth 27 lines.
+
+**What the count found.** Three of those claims are wrong. The `rules/`
+`del`s belong to `Classifier.look`, a *four*-parameter protocol, not to
+`LexemePass` -- only four of the 27 were the signature this document names.
+Five belonged to no protocol at all and were dead parameters. And there is no
+linter here to suppress an unused parameter, so `del` was not competing with
+one. ADR-012 has the table.
 
 ## What to audit before deciding
 
@@ -35,22 +47,29 @@ because a per-derivation check would be a lie.
 ## What went elsewhere
 
 - **Slot adjacency, the pass-list default, and `Scribe`'s draft identity** --
-  [ADR-011](../adr/011-where-a-slot-is.md). Adjacency moved onto
+  [ADR-011](../../adr/011-where-a-slot-is.md). Adjacency moved onto
   `Neighbourhood`, `passes` became required, and a dropped edge now raises
   instead of vanishing.
 - **`cross_word_noon` returning a role name** rather than the slot it created
-  -- [08](08-what-a-second-riwayah-decides.md), under `requires` as a
-  description. The builder greps the role name, so a script fact decides a
-  canonical question; the fix is the derivation returning the slot, and it is
-  bound up with what `requires` is allowed to mean.
+  -- [08](../../design/08-what-a-second-riwayah-decides.md), under `requires`
+  as a description. The builder greps the role name, so a script fact decides
+  a canonical question; the fix is the derivation returning the slot, and it
+  is bound up with what `requires` is allowed to mean.
 
-## Why this is last
+## Why this was last
 
 Nothing here blocks Warsh and nothing here is wrong in output. Unlike the
 three items that left, this one has no measurement that would settle it --
 only a preference about what a signature should show.
 
+**This was the mistaken part.** Counting the `del`s was the measurement, and
+it was available the whole time.
+
 ## Acceptance
 
 - Either the signature is unchanged and this document is closed as "no
   change", or every pass's true dependencies are visible without `del`.
+
+Met by the first branch, with the convention made checkable:
+`structure_lint`'s `signature-honesty` now fails on a protocol parameter a
+body neither reads nor `del`s.

--- a/docs/design/05-build-internals.md
+++ b/docs/design/05-build-internals.md
@@ -1,72 +1,15 @@
-# 05 - Adjacency, pass order, and slot identity
+# 05 - The five-object pass signature
 
-Status: **open**, lowest urgency. Audit: "Abstraction".
+Status: **open**, lowest urgency, and the last item of what was a four-part
+document. Audit: "Abstraction". The other three parts are
+[ADR-011](../adr/011-where-a-slot-is.md).
 
-Four separate defects that share one cause: `canon.build` and `rules/` have no
-agreed vocabulary for *where a slot is*, so each caller invents one.
-
-## The four
-
-### Slot adjacency is reimplemented per rule module
-
-Named helpers today:
-
-| module | helpers |
-|---|---|
-| `rules/boundary.py` | `_previous`, `_is_first_of_word`, `_is_last_of_word` |
-| `rules/madd.py` | `_before` |
-| `rules/tafkheem.py` | `_before` |
-
-Three modules, three implementations of two questions. The audit measured
-23,526 extra `Score.slots()` calls and about 1,686,196 extra slot items
-inspected over a full corpus run, but the cost is not the argument -- three
-copies of "the slot before this one" can disagree about a word boundary, and
-one of them would be wrong for a whole class of verses without any test
-noticing.
-
-`engine/neighbourhood.py` already exists and already knows the boundary plan.
-The question is whether adjacency belongs there (it has the plan, so it can
-answer "previous, joined or not") or on `Score` (it has the words, so it can
-answer "first of word" without a plan). They are different questions and may
-have different homes.
-
-### `build` falls back to `LEXEME_PASSES`
-
-`build(reading, passes=None)` uses `canon/passes.py:LEXEME_PASSES`. So there
-are two ways a pass list arrives and the default is the shared two. A riwayah
-that forgets to supply its own list gets a working pipeline that is silently
-not its own.
-
-Options: make `passes` required; or introduce a `BuildProfile` carrying the
-pass list with whatever else a riwayah configures about building, constructed
-by the composition root and never defaulted. The second is better if there
-turns out to be more than one such knob -- establish whether there is.
-
-Related and smaller: `cross_word_noon` returns a role name, so `canon` matches
-on an orthography string to find the slot it created. It should return the
-slot.
-
-### `Scribe` keys on `id()`
-
-`canon/scribe.py` links graphemes to draft slots by `id()` of a mutable
-object, valid only while `build`'s list is alive, and drops the link silently
-when the lookup misses. A dropped link is a written character anchored to no
-sound -- invisible in output, invisible in tests, and exactly the kind of
-thing the attestation gate exists to catch but cannot, because the gate reads
-the links that survived.
-
-Two changes, both uncontroversial in direction: give a draft a stable
-identity, and make a miss raise. The design content is only in what the
-identity is -- an ordinal assigned at draft creation is the obvious answer and
-survives the reordering that passes do, but that needs checking against
-`_skip_iwad_carrier` and the tanween split, both of which consume drafts.
-
-### The five-object pass signature
+## What is left
 
 A `LexemePass` takes `(reading, drafts, lexicon, scribe, selection)` whether
-it needs all five or not. 26 `del` statements across the package exist to say
+it needs all five or not. 27 `del` statements across the package exist to say
 "accepted and deliberately ignored", concentrated in `rules/boundary.py` (6),
-`rules/madd.py` (3) and `rules/annotation.py` (3).
+`rules/annotation.py` (3) and `rules/madd.py` (3).
 
 `del` is honest -- it makes the unused parameter explicit rather than letting
 a linter suppress it -- so this is not a bug. It is a signature that grew by
@@ -74,29 +17,40 @@ addition. A context object would collapse it, at the cost of making every
 pass's true dependencies invisible, which is the thing the `del`s currently
 make visible.
 
-Open, and genuinely two-sided: is the explicitness worth 26 lines.
+Open, and genuinely two-sided: is the explicitness worth 27 lines.
 
 ## What to audit before deciding
 
-1. **Diff the three adjacency implementations** against each other on a full
-   corpus run: for every slot, does each implementation return the same
-   answer. A disagreement is a live bug and promotes this document.
-2. **Count the riwayah build knobs.** If `passes` is the only one,
-   `BuildProfile` is premature and "make it required" is the answer.
-3. **Trace draft identity through the passes** that create, split or drop
-   drafts, and establish whether an ordinal assigned at creation stays stable.
-4. **For each `del`, whether the parameter is unused by that pass or unused
-   by that pass today.** The second is a signature that will need it back.
+For each `del`, whether the parameter is unused by that pass or unused by
+that pass *today*. The second is a signature that will need it back, and a
+context object would hide the moment it does.
+
+A second reading worth pricing: passes that need three of the five could
+declare which, and the caller supply only those. That keeps dependencies
+visible without the `del`s, but it needs a registration mechanism, and
+`canon/derive/vocabulary.py` is the cautionary example -- ADR-010 records
+that its `requires` tuples over-declare massively and are checked as a union
+because a per-derivation check would be a lie.
+
+## What went elsewhere
+
+- **Slot adjacency, the pass-list default, and `Scribe`'s draft identity** --
+  [ADR-011](../adr/011-where-a-slot-is.md). Adjacency moved onto
+  `Neighbourhood`, `passes` became required, and a dropped edge now raises
+  instead of vanishing.
+- **`cross_word_noon` returning a role name** rather than the slot it created
+  -- [08](08-what-a-second-riwayah-decides.md), under `requires` as a
+  description. The builder greps the role name, so a script fact decides a
+  canonical question; the fix is the derivation returning the slot, and it is
+  bound up with what `requires` is allowed to mean.
 
 ## Why this is last
 
-Nothing here blocks Warsh, and nothing here is wrong in output. Item 1 could
-change that -- if the three adjacency implementations disagree anywhere, this
-document moves to the top of the list.
+Nothing here blocks Warsh and nothing here is wrong in output. Unlike the
+three items that left, this one has no measurement that would settle it --
+only a preference about what a signature should show.
 
 ## Acceptance
 
-- One implementation of "the slot before this one" and one of "first/last of
-  word".
-- No pass list arrives by default.
-- A `Scribe` miss raises and names the address.
+- Either the signature is unchanged and this document is closed as "no
+  change", or every pass's true dependencies are visible without `del`.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,7 +20,6 @@ measured before choosing, and what would make the decision wrong.
 | | Question | Blocks |
 |---|---|---|
 | [03](03-canonical-vocabulary.md) | Do `Onset`, `SlotOrigin` and `Annotation` split? | projections |
-| [05](05-build-internals.md) | Is a pass's visible dependency list worth 27 `del`s? | nothing |
 | [06](06-seen-sad-khilaf.md) | How is the seen/sad khilaf authored and selected? | correctness today |
 | [08](08-what-a-second-riwayah-decides.md) | Does a script fact attach to a scalar or to a match? | Warsh |
 
@@ -35,12 +34,14 @@ wrong today rather than merely awkward.
 | 01 — mark semantics | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
 | 04 — data schemas | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
 | 07 — Warsh readiness | merged into 08 |
-| 05 — build internals | [ADR-011](../adr/011-where-a-slot-is.md) in part; one question left in place |
+| 05 — build internals | [ADR-011](../adr/011-where-a-slot-is.md), then [ADR-012](../adr/012-what-a-signature-may-leave-unsaid.md) |
 
 01, 04 and 07 each stalled at the same question, which is why 08 asks it once.
 What could be settled without answering it landed as ADR-010; the archived
 originals are in `docs/archive/design/`.
 
-05 is the one document that shrank rather than moved. Three of its four items
-had a single correct answer once measured and are ADR-011; the fourth has no
-measurement that would settle it, so the file stays open holding only that.
+05 left in two pieces. Three of its four items had a single correct answer
+once measured and are ADR-011; the fourth it described as having no
+measurement that would settle it, and counting the `del`s was that
+measurement -- ADR-012. Worth remembering when a document here claims an item
+is pure preference: 05 held that position for the item it had not counted.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,7 +20,7 @@ measured before choosing, and what would make the decision wrong.
 | | Question | Blocks |
 |---|---|---|
 | [03](03-canonical-vocabulary.md) | Do `Onset`, `SlotOrigin` and `Annotation` split? | projections |
-| [05](05-build-internals.md) | Who owns slot adjacency, pass order, and slot identity? | nothing yet |
+| [05](05-build-internals.md) | Is a pass's visible dependency list worth 27 `del`s? | nothing |
 | [06](06-seen-sad-khilaf.md) | How is the seen/sad khilaf authored and selected? | correctness today |
 | [08](08-what-a-second-riwayah-decides.md) | Does a script fact attach to a scalar or to a match? | Warsh |
 
@@ -35,7 +35,12 @@ wrong today rather than merely awkward.
 | 01 — mark semantics | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
 | 04 — data schemas | [ADR-010](../adr/010-constants-that-restate-data.md) in part, then merged into 08 |
 | 07 — Warsh readiness | merged into 08 |
+| 05 — build internals | [ADR-011](../adr/011-where-a-slot-is.md) in part; one question left in place |
 
 01, 04 and 07 each stalled at the same question, which is why 08 asks it once.
 What could be settled without answering it landed as ADR-010; the archived
 originals are in `docs/archive/design/`.
+
+05 is the one document that shrank rather than moved. Three of its four items
+had a single correct answer once measured and are ADR-011; the fourth has no
+measurement that would settle it, so the file stays open holding only that.

--- a/quranic_phonemizer/canon/assemble.py
+++ b/quranic_phonemizer/canon/assemble.py
@@ -15,7 +15,7 @@ def assemble(
     ordinals: dict[int, int] = {}
     sakt: set[int] = set()
     for ordinal, draft in enumerate(drafts):
-        ordinals[id(draft)] = ordinal
+        ordinals[draft.uid] = ordinal
         word = reading.clusters[draft.cluster].word if draft.cluster >= 0 else 0
         by_word.setdefault(word, []).append(_slot(reading, draft, ordinal))
         if draft.sakt_after:

--- a/quranic_phonemizer/canon/build.py
+++ b/quranic_phonemizer/canon/build.py
@@ -30,7 +30,7 @@ from .ledger import Ledger
 from .assemble import assemble
 from .draft import _Draft, set_fact
 from .juncture import apply_cross_word_noon
-from .passes import LEXEME_PASSES, LexemePass, apply_ledger
+from .passes import LexemePass, apply_ledger
 from .scribe import Scribe
 
 #: The two derivations the builder names itself. Both are properties of the
@@ -86,16 +86,16 @@ def build(
     selection: VariantSelection = VariantSelection(),
     provenance: Provenance | None = None,
     right_context: Reading | None = None,
-    passes: tuple[LexemePass, ...] | None = None,
+    passes: tuple[LexemePass, ...],
 ) -> Built:
-    """`right_context` is the next verse's reading and is not optional: some
-    cross-word tanween sites put the noon on a word in the following verse,
-    so verse scope alone is not sufficient."""
+    """`right_context` is the next verse's reading and is not optional: a
+    cross-word tanween site can put the noon on a word in the next verse.
+    `passes` has no default; a defaulted one would not be the riwayah's own."""
     track = provenance if provenance is not None else Provenance()
     scribe = Scribe(reading.verse)
     drafts = _drafts(reading, lexicon, track, right_context, scribe)
     apply_ledger(reading, drafts, ledger, track)
-    for lexeme_pass in (passes if passes is not None else LEXEME_PASSES):
+    for lexeme_pass in passes:
         lexeme_pass(reading, drafts, lexicon, scribe, selection)
     score, ordinals = assemble(reading, drafts, selection)
     return Built(score, scribe.finish(reading, drafts, ordinals))

--- a/quranic_phonemizer/canon/derive/lexeme.py
+++ b/quranic_phonemizer/canon/derive/lexeme.py
@@ -62,9 +62,9 @@ def allah_long_a(
     ]
 
 
-def relengthened(nucleus) -> Long:
-    del nucleus
-    return Long(Quality.A)
+#: What the divine name's short `a` becomes. A value, not a transform: the
+#: only relengthening there is has one answer, and `Long` is frozen.
+RELENGTHENED_A = Long(Quality.A)
 
 
 def otiose_waw(context: Context) -> bool:

--- a/quranic_phonemizer/canon/draft.py
+++ b/quranic_phonemizer/canon/draft.py
@@ -5,6 +5,7 @@ Shared by `build.py`'s per-cluster drafting and `passes.py`'s verse-level passes
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from itertools import count
 
 from ..model.canon import (
     Annotation,
@@ -16,6 +17,10 @@ from ..model.canon import (
 )
 from ..model.inscription import SlotFact
 from .derive import Target
+
+#: Never serialised and never compared across builds -- only a key while one
+#: verse is being drafted, so a process-wide counter is enough.
+_uid = count()
 
 
 @dataclass(slots=True)
@@ -34,6 +39,10 @@ class _Draft:
     it onto the `ScoreWord`."""
 
     annotations: frozenset[Annotation] = frozenset()
+
+    uid: int = field(default_factory=lambda: next(_uid))
+    """Identity that survives being moved, split or dropped, which `id()` did
+    not. Also what makes `list.remove` and `list.index` mean this draft."""
 
 
 def fact_of(draft, fact: SlotFact):

--- a/quranic_phonemizer/canon/passes.py
+++ b/quranic_phonemizer/canon/passes.py
@@ -5,10 +5,9 @@ which the per-cluster derivation registry cannot express.
 """
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TypeAlias
+from typing import Protocol
 
-from ..model.address import VerseRef
+from ..model.address import VariantSelection, VerseRef
 from ..model.canon import (
     ABJAD,
     Annotation,
@@ -22,9 +21,10 @@ from ..model.canon import (
 from ..model.inscription import SlotFact
 from ..orthography.adapter import Reading
 from .derive import Target, lexeme
-from .draft import fact_of, set_fact
+from .draft import _Draft, fact_of, set_fact
 from .ledger import Ledger, VerseSlot, WordSlot
 from .lexicon import Lexicon
+from .scribe import Scribe
 
 
 class LedgerAddressError(ValueError):
@@ -40,14 +40,23 @@ def word_of(reading: Reading, draft) -> int:
     which imports this module rather than the other way round."""
     return reading.clusters[draft.cluster].word if draft.cluster >= 0 else -1
 
-#: A pass over the drafted slots of a whole verse, after every per-cluster
-#: derivation has run. `(reading, drafts, lexicon, scribe, selection) -> None`.
-#:
-#: The scribe is in the signature because a pass may *create* slots -- spelling
-#: `الٓمٓصٓ` turns three into seven -- and every slot must trace to a grapheme.
-#: The selection is, because a khilaf can put a different vowel in the Score.
-#: A pass that needs neither can ignore them.
-LexemePass: TypeAlias = Callable[[Reading, list, object, object, object], None]
+# The scribe is in the signature because a pass may *create* slots -- spelling
+# `الٓمٓصٓ` turns three into seven -- and every slot must trace to a grapheme.
+# The selection is, because a khilaf can put a different vowel in the Score.
+# A pass needing neither `del`s them, so what it ignores is visible where it
+# is ignored rather than absent from the signature.
+class LexemePass(Protocol):
+    """A pass over the drafted slots of a whole verse, after every per-cluster
+    derivation has run."""
+
+    def __call__(
+        self,
+        reading: Reading,
+        drafts: list[_Draft],
+        lexicon: Lexicon,
+        scribe: Scribe | None,
+        selection: VariantSelection,
+    ) -> None: ...
 
 
 def apply_ledger(reading: Reading, drafts, ledger: Ledger, track) -> None:
@@ -139,14 +148,14 @@ def _check_skeleton(reading: Reading, drafts, ordinal: int, claimed: str) -> Non
 
 
 def _apply_allah_lexeme(
-    reading: Reading, drafts, lexicon=None, scribe=None, selection=None
+    reading: Reading, drafts, lexicon, scribe, selection
 ) -> None:
     """Word by word, not verse by verse: the lexeme is a property of one word.
 
     Run over the whole verse instead, a word ending in lam or hamza would
     lend its last slot to the next word's opening lam.
     """
-    del scribe
+    del scribe, selection
     for word_index in range(len(reading.words)):
         span = [d for d in drafts if word_of(reading, d) == word_index]
         letters = [d.letter for d in span]
@@ -163,7 +172,7 @@ PLURAL_HOSTS = frozenset({CanonLetter.KAF, CanonLetter.HEH})
 
 
 def connect_plural_meem(
-    reading: Reading, drafts, lexicon=None, scribe=None, selection=None
+    reading: Reading, drafts, lexicon, scribe, selection
 ) -> None:
     """The plural pronoun's meem takes a damma before a prosthetic hamza.
 
@@ -194,11 +203,12 @@ def _plural_meem(span) -> bool:
 
 
 def _apply_pausal_lexemes(
-    reading: Reading, drafts, lexicon: Lexicon, scribe=None, selection=None
+    reading: Reading, drafts, lexicon: Lexicon, scribe, selection
 ) -> None:
     """The seven alifs. Uthmani marks them `۠`; IndoPak writes a plain final
     alif, indistinguishable from an ordinary length carrier - so the fact is
     lexical, not orthographic."""
+    del scribe, selection
     if not lexicon.pausal_lexemes:
         return
     for word_index in range(len(reading.words)):

--- a/quranic_phonemizer/canon/passes.py
+++ b/quranic_phonemizer/canon/passes.py
@@ -155,7 +155,7 @@ def _apply_allah_lexeme(
         for index in lexeme.divine_name(letters, nuclei, onsets, lexicon):
             span[index].annotations |= {Annotation.DIVINE_NAME}
         for index in lexeme.allah_long_a(letters, nuclei, onsets, lexicon):
-            span[index].nucleus = lexeme.relengthened(span[index].nucleus)
+            span[index].nucleus = lexeme.RELENGTHENED_A
 
 
 #: What the plural meem attaches to. `ـكُمْ` and `ـهُمْ`, in either person.

--- a/quranic_phonemizer/canon/scribe.py
+++ b/quranic_phonemizer/canon/scribe.py
@@ -20,12 +20,16 @@ from ..model.inscription import (
 )
 
 
+class OrphanedEdgeError(ValueError):
+    """A recorded edge points at a draft no slot came from."""
+
+
 @dataclass(slots=True)
 class Scribe:
     """Collects the edges. One per `build` call, discarded after `finish`.
 
-    Drafts are identified by `id()`, valid only while `build`'s own list
-    keeps them alive.
+    Drafts are identified by `_Draft.uid`, so a pass that drops one has to
+    say what becomes of its edges rather than leaving them to fall out.
     """
 
     verse: VerseRef
@@ -37,30 +41,35 @@ class Scribe:
         """`subject` is the draft the fact landed on, which is not always the
         cluster that carried the mark."""
         if offset >= 0 and subject is not None:
-            self.evidences.append((offset, id(subject), fact))
+            self.evidences.append((offset, subject.uid, fact))
 
     def decoration(self, offset: int, subject) -> None:
         if offset >= 0 and subject is not None:
-            self.decorates.append((offset, id(subject)))
+            self.decorates.append((offset, subject.uid))
 
     def attestation(self, offset: int, family: RuleFamily, anchor) -> None:
         if offset >= 0 and anchor is not None:
-            self.attests.append((offset, family, id(anchor)))
+            self.attests.append((offset, family, anchor.uid))
+
+    def withdraw(self, drafts) -> None:
+        """Every edge into these drafts, dropped. For a pass that replaces a
+        span wholesale: the graphemes are re-evidenced onto what replaces it."""
+        gone = {draft.uid for draft in drafts}
+        self.evidences = [row for row in self.evidences if row[1] not in gone]
+        self.decorates = [row for row in self.decorates if row[1] not in gone]
+        self.attests = [row for row in self.attests if row[2] not in gone]
 
     def finish(self, reading, drafts, ordinals: dict[int, int]) -> Inscription:
         spellings: list[Spelling] = []
         for offset, key, fact in self.evidences:
-            slot = _slot(self.verse, ordinals, key)
-            if slot is not None:
-                spellings.append(Evidences(_grapheme(self.verse, offset), slot, fact))
+            slot = _slot(self.verse, ordinals, key, offset)
+            spellings.append(Evidences(_grapheme(self.verse, offset), slot, fact))
         for offset, key in self.decorates:
-            slot = _slot(self.verse, ordinals, key)
-            if slot is not None:
-                spellings.append(Decorates(_grapheme(self.verse, offset), slot))
+            slot = _slot(self.verse, ordinals, key, offset)
+            spellings.append(Decorates(_grapheme(self.verse, offset), slot))
         for offset, family, key in self.attests:
-            slot = _slot(self.verse, ordinals, key)
-            if slot is not None:
-                spellings.append(Attests(_grapheme(self.verse, offset), family, slot))
+            slot = _slot(self.verse, ordinals, key, offset)
+            spellings.append(Attests(_grapheme(self.verse, offset), family, slot))
         for offset in reading.structural:
             spellings.append(Structural(_grapheme(self.verse, offset)))
         spellings.extend(self._decorations(reading, drafts, ordinals))
@@ -79,9 +88,9 @@ class Scribe:
         not know which clusters become slots. A mark on rasm has no cluster
         of its own, so it falls back to the last slot before it."""
         by_cluster = {
-            draft.cluster: ordinals[id(draft)]
+            draft.cluster: ordinals[draft.uid]
             for draft in drafts
-            if draft.cluster >= 0 and id(draft) in ordinals
+            if draft.cluster >= 0
         }
         ordered = sorted(by_cluster)
         for decoration in reading.decorations:
@@ -99,9 +108,17 @@ class Scribe:
             )
 
 
-def _slot(verse: VerseRef, ordinals: dict[int, int], key: int) -> SlotId | None:
+def _slot(verse: VerseRef, ordinals: dict[int, int], key: int, offset: int) -> SlotId:
+    """A miss is a written character anchored to no sound, which is invisible
+    in output and in every gate. It raises instead."""
     ordinal = ordinals.get(key)
-    return None if ordinal is None else SlotId(verse, ordinal)
+    if ordinal is None:
+        raise OrphanedEdgeError(
+            f"{verse.surah}:{verse.ayah} offset {offset}: edge into draft "
+            f"{key}, which no slot came from. A pass that drops a draft must "
+            f"withdraw its edges."
+        )
+    return SlotId(verse, ordinal)
 
 
 def _grapheme(verse: VerseRef, offset: int) -> GraphemeId:

--- a/quranic_phonemizer/canon/spell.py
+++ b/quranic_phonemizer/canon/spell.py
@@ -127,6 +127,9 @@ def spell_muqattaat(names: Muqattaat):
                 drafts.remove(draft)
             drafts[first:first] = spelled
             if scribe is not None:
+                # The letter names replace the word's drafts, so the edges
+                # drafting recorded into them are withdrawn, not orphaned.
+                scribe.withdraw(span)
                 # The compact grapheme evidences every slot its name expands
                 # to, so `الٓمٓصٓ` gives three graphemes reaching seven slots,
                 # keeping every slot traceable to a grapheme.

--- a/quranic_phonemizer/canon/spell.py
+++ b/quranic_phonemizer/canon/spell.py
@@ -110,7 +110,7 @@ def spell_muqattaat(names: Muqattaat):
     """Build the pass. Bound by the riwayah like the other lexeme passes."""
 
     def apply(
-        reading: Reading, drafts: list, lexicon, scribe=None, selection=None
+        reading: Reading, drafts: list, lexicon, scribe, selection
     ) -> None:
         del lexicon, selection
         for word in range(len(reading.words)):

--- a/quranic_phonemizer/engine/laws.py
+++ b/quranic_phonemizer/engine/laws.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from ..model.address import BoundaryPlan, SlotId
+from ..model.address import SlotId
 from ..model.canon import CLASSIFICATION_ONLY, FAMILY_OF, RuleFamily, Score
 from ..model.inscription import Attests, Decorates, Evidences, Inscription
 from ..model.performance import (
@@ -145,14 +145,12 @@ def check_inscription(inscription: Inscription, score: Score) -> None:
 def check_attestations(
     attested: Iterable[tuple[SlotId, RuleFamily]],
     performance: Performance,
-    boundaries: BoundaryPlan,
 ) -> list[str]:
     """Every family a script attests must be produced by some occurrence.
 
     One-directional: an occurrence family with no matching attestation is
     not an error. Returns disagreements instead of raising them individually.
     """
-    del boundaries
     produced: dict[SlotId, set[RuleFamily]] = {}
     for occurrence in performance.occurrences:
         family = FAMILY_OF[occurrence.rule]

--- a/quranic_phonemizer/engine/neighbourhood.py
+++ b/quranic_phonemizer/engine/neighbourhood.py
@@ -44,6 +44,30 @@ class Neighbourhood:
         following = self._flat[position + 1]
         return None if self._blocked(at, following.id) else following
 
+    def before(self, at: SlotId) -> Slot | None:
+        """The previous slot in recitation order, junctions ignored.
+
+        Deliberately not the mirror of `after`: a stop blocks the view
+        forward because recitation ends there, but the slot behind was said.
+        """
+        position = self._at.get(at)
+        if not position:
+            return None
+        return self._flat[position - 1]
+
+    def first_of_word(self, at: SlotId) -> bool:
+        position, word = self._at.get(at), self._word.get(at)
+        if position is None or word is None:
+            return False
+        return position == 0 or self._word[self._flat[position - 1].id] != word
+
+    def last_of_word(self, at: SlotId) -> bool:
+        position, word = self._at.get(at), self._word.get(at)
+        if position is None or word is None:
+            return False
+        end = position + 1 == len(self._flat)
+        return end or self._word[self._flat[position + 1].id] != word
+
     def crosses_word(self, at: SlotId) -> bool:
         following = self.after(at)
         return following is not None and self._word[at] != self._word[following.id]

--- a/quranic_phonemizer/engine/run.py
+++ b/quranic_phonemizer/engine/run.py
@@ -74,7 +74,6 @@ def perform(
 ) -> Performance:
     plan = Plan()
     slots = score.slots()
-    index = {slot.id: slot for slot in slots}
 
     near = Neighbourhood(score, boundaries)
     for phase in PHASE_ORDER:
@@ -89,10 +88,10 @@ def perform(
                 if verdict is not None:
                     plan.record(phase, verdict)
 
-    return _materialise(plan, index, score, boundaries, selection)
+    return _materialise(plan, score, boundaries, selection)
 
 
-def _fill_plain(plan: Plan, score: Score, mint: _Mint) -> list[tuple]:
+def _fill_plain(plan: Plan, score: Score) -> list[tuple]:
     """Realize every (slot, aspect) no verdict claimed, tagged `Rule.PLAIN`.
 
     `PLAIN` can't be a classifier: it would conflict with every claiming rule.
@@ -110,7 +109,6 @@ def _fill_plain(plan: Plan, score: Score, mint: _Mint) -> list[tuple]:
             if not has_content(slot, aspect) or (slot.id, aspect) in claimed:
                 continue
             filled.append((slot, aspect))
-    del mint
     return filled
 
 
@@ -134,7 +132,6 @@ def _triggered(classifier, slot: Slot) -> bool:
 
 def _materialise(
     plan: Plan,
-    index: dict[SlotId, Slot],
     score: Score,
     boundaries: BoundaryPlan,
     selection: VariantSelection,
@@ -161,7 +158,6 @@ def _materialise(
     _fill(plan, score, mint, colours, sounds, attributions, hosted, plain)
     _resolve_merges(plan, hosted, attributions)
 
-    del index
     return Performance(
         riwayah=score.riwayah,
         sounds=tuple(sounds),
@@ -218,7 +214,7 @@ def _fill(plan, score, mint, colours, sounds, attributions, hosted, plain) -> No
     lengths = {
         e.slot: e.length for e in plan.effects() if isinstance(e, Relength)
     }
-    for slot, aspect in _fill_plain(plan, score, mint):
+    for slot, aspect in _fill_plain(plan, score):
         sound_id = mint.sound()
         sounds.append((sound_id, _plain_sound(slot, aspect, colours, lengths)))
         hosted[(slot.id, aspect)] = sound_id

--- a/quranic_phonemizer/rules/boundary.py
+++ b/quranic_phonemizer/rules/boundary.py
@@ -63,7 +63,7 @@ class WaqfEnding:
             return None
         if not _is_final_letter(near, at, word):
             return None
-        if _followed_by_tanween_noon(near, at, word) and (
+        if _followed_by_tanween_noon(near, word) and (
             slot.letter is not CanonLetter.TAA_MARBUTA
         ):
             # TanweenAtWaqf owns the ending; taa marbuta drops its vowel here instead.
@@ -256,8 +256,7 @@ def _is_final_letter(near: Neighbourhood, at: SlotId, word: int) -> bool:
     return bool(slots) and slots[-1].id == at
 
 
-def _followed_by_tanween_noon(near: Neighbourhood, at: SlotId, word: int) -> bool:
-    del at
+def _followed_by_tanween_noon(near: Neighbourhood, word: int) -> bool:
     slots = near.score.words[word].slots
     return bool(slots) and slots[-1].origin is SlotOrigin.NUNATION
 

--- a/quranic_phonemizer/rules/boundary.py
+++ b/quranic_phonemizer/rules/boundary.py
@@ -83,7 +83,7 @@ class WaqfEnding:
             # The pronoun yaa's onset must go too, or a stray glide remains,
             # and the stop then lands on the letter before it.
             effects.append(Silence(at, Aspect.ONSET))
-            effects.extend(_hands_the_stop_back(near, at, word))
+            effects.extend(_hands_the_stop_back(near, at))
         if not effects:
             return None
         return Verdict(
@@ -123,7 +123,7 @@ class WaslHamza:
         slot, word = near.slot(at), near.word_of(at)
         if slot is None or word is None or slot.onset is not Onset.WASL:
             return None
-        if boundaries.started_on(word) and _is_first_of_word(near, at, word):
+        if boundaries.started_on(word) and near.first_of_word(at):
             return Verdict(
                 Occurrence(mint(Rule.WASL_START, at), Rule.WASL_START, Participants((at,))), ()
             )
@@ -150,7 +150,7 @@ class SoftenedHamza:
         slot, word = near.slot(at), near.word_of(at)
         if slot is None or word is None or slot.onset is not Onset.WASL:
             return None
-        if not (boundaries.started_on(word) and _is_first_of_word(near, at, word)):
+        if not (boundaries.started_on(word) and near.first_of_word(at)):
             return None   # joined, the prosthetic hamza has no vowel to carry
         following = near.after(at)
         if (
@@ -191,11 +191,11 @@ class TanweenAtWaqf:
         slot, word = near.slot(at), near.word_of(at)
         if slot is None or word is None or not boundaries.stopped_on(word):
             return None
-        if not _is_last_of_word(near, at, word):
+        if not near.last_of_word(at):
             return None
         if slot.origin is not SlotOrigin.NUNATION:
             return None
-        base = _previous(near, at)
+        base = near.before(at)
         if base is None or base.nucleus.kind is not NucleusKind.SHORT:
             return None
         effects = [Silence(at, Aspect.ONSET)]
@@ -262,32 +262,12 @@ def _followed_by_tanween_noon(near: Neighbourhood, at: SlotId, word: int) -> boo
     return bool(slots) and slots[-1].origin is SlotOrigin.NUNATION
 
 
-def _previous(near: Neighbourhood, at: SlotId):
-    flat = near.score.slots()
-    for index, slot in enumerate(flat):
-        if slot.id == at:
-            return flat[index - 1] if index else None
-    return None
-
-
-def _is_last_of_word(near: Neighbourhood, at: SlotId, word: int) -> bool:
-    slots = near.score.words[word].slots
-    return bool(slots) and slots[-1].id == at
-
-
-def _is_first_of_word(near: Neighbourhood, at: SlotId, word: int) -> bool:
-    slots = near.score.words[word].slots
-    return bool(slots) and slots[0].id == at
-
-
-def _hands_the_stop_back(near: Neighbourhood, at: SlotId, word: int):
+def _hands_the_stop_back(near: Neighbourhood, at: SlotId):
     """A letter absent at the pause is not the one stopped on, so the vowel
     of the letter before it drops instead."""
-    slots = near.score.words[word].slots
-    index = next((i for i, s in enumerate(slots) if s.id == at), 0)
-    if index == 0:
+    if near.first_of_word(at):
         return ()
-    before = slots[index - 1]
-    if before.nucleus.kind is not NucleusKind.SHORT:
+    before = near.before(at)
+    if before is None or before.nucleus.kind is not NucleusKind.SHORT:
         return ()
     return (Silence(before.id, Aspect.NUCLEUS),)

--- a/quranic_phonemizer/rules/madd.py
+++ b/quranic_phonemizer/rules/madd.py
@@ -57,7 +57,7 @@ class PausalGlide:
             # A glide the stop cannot strip still carries its own vowel, so it
             # is a consonant: `نَسِيَا` ends `-iyaa`, not `-iiaa`.
             return None
-        before = _before(near, at)
+        before = near.before(at)
         if before is None or before.nucleus.kind is not NucleusKind.SHORT:
             return None
         if GLIDE_OF.get(before.nucleus.quality) is not slot.letter:
@@ -138,14 +138,6 @@ def _opens_on_a_sakin(slot) -> bool:
     )
 
 
-def _before(near: Neighbourhood, at: SlotId):
-    flat = near.score.slots()
-    for index, slot in enumerate(flat):
-        if slot.id == at:
-            return flat[index - 1] if index else None
-    return None
-
-
 @dataclass(frozen=True, slots=True)
 class MaddClass:
     """Which madd this long vowel is -- one classifier, five outcomes.
@@ -223,7 +215,7 @@ class MaddLeen:
             return None
         if slot.onset is Onset.GEMINATE:
             return None
-        before = _before(near, at)
+        before = near.before(at)
         if before is None or before.nucleus.kind is not NucleusKind.SHORT:
             return None
         if before.nucleus.quality is not Quality.A:

--- a/quranic_phonemizer/rules/tafkheem.py
+++ b/quranic_phonemizer/rules/tafkheem.py
@@ -97,7 +97,7 @@ class Emphasis:
 
 def _raa_is_heavy(near, slot, plan, always_heavy) -> bool:
     """The quiescent raa, whose vowel is gone or was never there."""
-    before = _before(near, slot)
+    before = near.before(slot.id)
     if (
         before is not None
         and before.letter is L.YA
@@ -145,22 +145,14 @@ def _governing(near: Neighbourhood, slot, plan):
     Skips a canonically silent slot and one a BOUNDARY rule elided: the wasl
     hamza's helping vowel is not spoken mid-word.
     """
-    before = _before(near, slot)
+    before = near.before(slot.id)
     for _ in range(MAX_LOOKBACK):
         if before is None:
             return None
         silent = before.nucleus.kind is NucleusKind.SILENT
         if not (silent or _silenced(plan, before)):
             return before
-        before = _before(near, before)
-    return None
-
-
-def _before(near: Neighbourhood, slot):
-    flat = near.score.slots()
-    for index, other in enumerate(flat):
-        if other.id == slot.id:
-            return flat[index - 1] if index else None
+        before = near.before(before.id)
     return None
 
 

--- a/tests/test_attestation_law.py
+++ b/tests/test_attestation_law.py
@@ -33,8 +33,8 @@ def _performed(packed, hafs, surah: int, ayah: int):
 
 @pytest.mark.parametrize("surah,ayah", MERGERS)
 def test_a_written_shadda_is_accounted_for(packed, hafs, surah, ayah) -> None:
-    attested, performance, plan = _performed(packed, hafs, surah, ayah)
-    assert not check_attestations(attested, performance, plan)
+    attested, performance, _ = _performed(packed, hafs, surah, ayah)
+    assert not check_attestations(attested, performance)
 
 
 @pytest.mark.parametrize("surah,ayah", MERGERS)

--- a/tests/test_build_contract.py
+++ b/tests/test_build_contract.py
@@ -6,7 +6,14 @@ import inspect
 import pytest
 
 from quranic_phonemizer.canon.build import build
+from quranic_phonemizer.canon.draft import _Draft
+from quranic_phonemizer.canon.scribe import OrphanedEdgeError, Scribe
 from quranic_phonemizer.model.address import Script, VerseRef
+from quranic_phonemizer.model.canon import CanonLetter
+from quranic_phonemizer.model.inscription import SlotFact
+
+#: The muqattaat openings, the only place a pass replaces a whole word's drafts.
+COMPACT = ((2, 1), (3, 1), (19, 1), (42, 1))
 
 
 def _reading(hafs, surah: int = 112, ayah: int = 2):
@@ -20,3 +27,59 @@ def test_a_pass_list_never_arrives_by_default(hafs) -> None:
     assert inspect.signature(build).parameters["passes"].default is inspect.Parameter.empty
     with pytest.raises(TypeError, match="passes"):
         build(_reading(hafs), lexicon=hafs.lexicon, ledger=hafs.ledger)
+
+
+# -- draft identity ---
+
+def test_two_drafts_alike_in_every_field_are_still_two_drafts() -> None:
+    """`list.remove` and `list.index` compare by value, so without this a
+    span could be spliced at an identical draft in an earlier word."""
+    one, other = _Draft(letter=CanonLetter.ALIF), _Draft(letter=CanonLetter.ALIF)
+    assert one != other
+    drafts = [one, other]
+    assert drafts.index(other) == 1
+    drafts.remove(other)
+    assert drafts == [one]
+
+
+@pytest.mark.parametrize("surah,ayah", COMPACT)
+def test_a_replaced_span_leaves_no_edge_behind(hafs, surah, ayah) -> None:
+    """The muqattaat pass drops a word's drafts and spells the letter names
+    in their place. Building at all is the assertion: an edge into a dropped
+    draft now raises where it used to vanish."""
+    verse = VerseRef(surah, ayah)
+    built = hafs.build(hafs.read(Script.UTHMANI, verse, hafs.words(verse)))
+    reached = {
+        spelling.slot.ordinal
+        for spelling in built.inscription.spellings
+        if getattr(spelling, "slot", None) is not None
+    }
+    spelled = {slot.id.ordinal for slot in built.score.words[0].slots}
+    assert spelled <= reached, f"unreached: {sorted(spelled - reached)}"
+
+
+def test_an_edge_into_a_dropped_draft_raises(hafs) -> None:
+    """Falsifier: dropping `Scribe.withdraw` from the muqattaat pass sends
+    every opening's edges down this path, and each used to vanish in silence."""
+    verse = VerseRef(112, 2)
+    reading = hafs.read(Script.UTHMANI, verse, hafs.words(verse))
+    scribe = Scribe(verse)
+    scribe.evidence(0, _Draft(letter=CanonLetter.ALIF), SlotFact.LETTER)
+    with pytest.raises(OrphanedEdgeError, match="no slot came from"):
+        scribe.finish(reading, [], {})
+
+
+def test_withdrawing_a_draft_takes_all_three_kinds_of_edge(hafs) -> None:
+    from quranic_phonemizer.model.canon import RuleFamily
+
+    verse = VerseRef(112, 2)
+    draft, kept = _Draft(letter=CanonLetter.ALIF), _Draft(letter=CanonLetter.MEEM)
+    scribe = Scribe(verse)
+    for subject in (draft, kept):
+        scribe.evidence(0, subject, SlotFact.LETTER)
+        scribe.decoration(1, subject)
+        scribe.attestation(2, RuleFamily.LENGTHENING, subject)
+    scribe.withdraw([draft])
+    assert [row[1] for row in scribe.evidences] == [kept.uid]
+    assert [row[1] for row in scribe.decorates] == [kept.uid]
+    assert [row[2] for row in scribe.attests] == [kept.uid]

--- a/tests/test_build_contract.py
+++ b/tests/test_build_contract.py
@@ -1,0 +1,22 @@
+"""What `canon.build` requires of its caller, and what it promises back."""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from quranic_phonemizer.canon.build import build
+from quranic_phonemizer.model.address import Script, VerseRef
+
+
+def _reading(hafs, surah: int = 112, ayah: int = 2):
+    verse = VerseRef(surah, ayah)
+    return hafs.read(Script.UTHMANI, verse, hafs.words(verse))
+
+
+def test_a_pass_list_never_arrives_by_default(hafs) -> None:
+    """A riwayah that forgot its own passes used to get the shared two and a
+    working pipeline that was not its own."""
+    assert inspect.signature(build).parameters["passes"].default is inspect.Parameter.empty
+    with pytest.raises(TypeError, match="passes"):
+        build(_reading(hafs), lexicon=hafs.lexicon, ledger=hafs.ledger)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -235,7 +235,7 @@ def test_an_entry_for_this_verse_that_does_not_resolve_is_an_error(
         asserts=(),
     )
     with pytest.raises(LedgerAddressError, match="does not resolve"):
-        build(reading, lexicon=hafs.lexicon, ledger=beyond)
+        build(reading, lexicon=hafs.lexicon, ledger=beyond, passes=hafs.passes)
 
 
 def test_an_assert_the_script_does_not_write_is_an_error(hafs) -> None:
@@ -289,4 +289,4 @@ def test_an_entry_for_another_verse_is_not_an_error(packed, hafs) -> None:
         ),
         asserts=(),
     )
-    build(reading, lexicon=hafs.lexicon, ledger=elsewhere)
+    build(reading, lexicon=hafs.lexicon, ledger=elsewhere, passes=hafs.passes)

--- a/tests/test_neighbourhood.py
+++ b/tests/test_neighbourhood.py
@@ -1,0 +1,75 @@
+"""Where a slot is, asked once.
+
+Three rule modules each carried their own "the slot before this one". These
+tests pin the answers the shared one has to keep giving.
+"""
+from __future__ import annotations
+
+from conftest import score_for
+from quranic_phonemizer.engine.boundary_plan import all_join
+from quranic_phonemizer.engine.neighbourhood import Neighbourhood
+from quranic_phonemizer.model.address import BoundaryPlan, Junction, SlotId
+
+
+def _near(packed, hafs, surah: int, ayah: int, boundaries=None) -> Neighbourhood:
+    score = score_for(packed, hafs, surah, ayah)
+    plan = boundaries or all_join(len(score.words))
+    return Neighbourhood(score=score, boundaries=plan)
+
+
+def test_before_walks_the_verse_in_recitation_order(packed, hafs) -> None:
+    near = _near(packed, hafs, 1, 2)
+    flat = near.score.slots()
+    for index, slot in enumerate(flat):
+        got = near.before(slot.id)
+        want = flat[index - 1] if index else None
+        assert got is want, f"at {slot.id} ({index})"
+
+
+def test_the_first_slot_of_a_verse_has_nothing_before_it(packed, hafs) -> None:
+    near = _near(packed, hafs, 1, 2)
+    assert near.before(near.score.slots()[0].id) is None
+
+
+def test_an_unknown_slot_has_no_neighbours(packed, hafs) -> None:
+    near = _near(packed, hafs, 1, 2)
+    stranger = SlotId(near.score.words[0].location.verse, 9999)
+    assert near.before(stranger) is None
+    assert near.first_of_word(stranger) is False
+    assert near.last_of_word(stranger) is False
+
+
+def test_a_stop_blocks_the_view_forward_but_not_backward(packed, hafs) -> None:
+    """The asymmetry three rule modules relied on and none of them wrote down:
+    recitation ends at a stop, but the slot behind it was still said."""
+    score = score_for(packed, hafs, 1, 2)
+    stops = BoundaryPlan((Junction.STOP,) * (len(score.words) - 1) + (Junction.EDGE,))
+    near = Neighbourhood(score=score, boundaries=stops)
+    flat = score.slots()
+    crossings = [
+        (flat[index - 1], slot)
+        for index, slot in enumerate(flat)
+        if index and near.word_of(slot.id) != near.word_of(flat[index - 1].id)
+    ]
+    assert crossings, "verse has no word boundary to test"
+    for earlier, later in crossings:
+        assert near.after(earlier.id) is None
+        assert near.before(later.id) is earlier
+
+
+def test_first_and_last_of_word_agree_with_the_score(packed, hafs) -> None:
+    near = _near(packed, hafs, 2, 1)
+    for word in near.score.words:
+        if not word.slots:
+            continue
+        for position, slot in enumerate(word.slots):
+            assert near.first_of_word(slot.id) is (position == 0)
+            assert near.last_of_word(slot.id) is (position == len(word.slots) - 1)
+
+
+def test_a_one_slot_word_is_both_its_first_and_its_last(packed, hafs) -> None:
+    near = _near(packed, hafs, 108, 1)
+    singles = [word for word in near.score.words if len(word.slots) == 1]
+    for word in singles:
+        only = word.slots[0].id
+        assert near.first_of_word(only) and near.last_of_word(only)

--- a/tools/attest.py
+++ b/tools/attest.py
@@ -39,7 +39,7 @@ def unmet(hafs, script: Script, ref: VerseRef, words) -> tuple[list[str], int]:
         for s in built.inscription.spellings
         if isinstance(s, Attests)
     ]
-    return check_attestations(attested, performance, plan), len(attested)
+    return check_attestations(attested, performance), len(attested)
 
 
 def main() -> int:

--- a/tools/structure_lint.py
+++ b/tools/structure_lint.py
@@ -57,6 +57,15 @@ SIDE_EFFECT = frozenset({"annotations"})
 #: Roles the inventory loader supplies rather than any file naming them.
 LOADER_ROLES = frozenset({"seat", "structural", "advice"})
 
+#: The two callback protocols, by parameter names: `Classifier.look` and
+#: `LexemePass`. A protocol is the only thing that hands an implementation a
+#: parameter it may not want, so these are where an unread one is legitimate
+#: -- and where it has to be `del`ed rather than left silent.
+PROTOCOLS = {
+    ("near", "plan", "at", "boundaries"),
+    ("reading", "drafts", "lexicon", "scribe", "selection"),
+}
+
 MAX_FILE_LINES = 400
 MAX_FUNCTION_LINES = 50
 
@@ -412,10 +421,73 @@ def role_vocabulary() -> list[Problem]:
     return out
 
 
+def _parameters(node) -> tuple[str, ...]:
+    """Positional and keyword-only names, less `self`. Keyed on names rather
+    than on the function's own name, so an implementation is recognised by
+    the protocol it satisfies."""
+    args = node.args
+    return tuple(
+        arg.arg
+        for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs)
+        if arg.arg != "self"
+    )
+
+
+def _is_stub(node) -> bool:
+    """A Protocol's own body is a docstring and `...`: it declares the
+    parameters and by construction reads none of them."""
+    return not [
+        statement
+        for statement in node.body
+        if not (
+            isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Constant)
+        )
+    ]
+
+
+def _accounted_for(node) -> set[str]:
+    """Every name the body reads or deletes. A nested closure counts as the
+    enclosing function reading it, which is what a pass built by a factory
+    needs."""
+    out = set()
+    for inner in ast.walk(node):
+        if isinstance(inner, ast.Name) and isinstance(inner.ctx, ast.Load):
+            out.add(inner.id)
+        elif isinstance(inner, ast.Delete):
+            out |= {t.id for t in inner.targets if isinstance(t, ast.Name)}
+    return out
+
+
+def signature_honesty() -> list[Problem]:
+    """A protocol parameter an implementation neither reads nor `del`s.
+
+    Nothing else here looks at signatures, so without this an absent `del`
+    cannot be told from a parameter the author forgot.
+    """
+    out: list[Problem] = []
+    for path, tree in _modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            parameters = _parameters(node)
+            if parameters not in PROTOCOLS or _is_stub(node):
+                continue
+            accounted = _accounted_for(node)
+            out.extend(
+                (path, node.lineno, "signature-honesty",
+                 f"{node.name} ignores {name!r} without a `del`")
+                for name in parameters
+                if name not in accounted
+            )
+    return out
+
+
 CHECKS = {
     "import-graph": import_graph,
     "unused-imports": unused_imports,
     "role-vocabulary": role_vocabulary,
+    "signature-honesty": signature_honesty,
     "module-size": module_size,
     "dead-exports": dead_exports,
     "phoneme-strings": phoneme_strings,


### PR DESCRIPTION
All four items in design question 05. `canon.build` and `rules/` had no agreed vocabulary for *where a slot is*, so each caller invented one — and the fourth item, which the document said could only be settled by preference, turned out to have a measurement nobody had taken.

Recorded as [ADR-011](docs/adr/011-where-a-slot-is.md) and [ADR-012](docs/adr/012-what-a-signature-may-leave-unsaid.md).

## 1. Three copies of "the slot before this one"

`boundary._previous`, `madd._before` and `tafkheem._before` were the same algorithm — rebuild the flat slot list with `Score.slots()`, scan it for the id, take the one before. `Neighbourhood` already held that list, an index into it, and the forward question `after()`.

So `before`, `first_of_word` and `last_of_word` join `after` there, and five helpers go. The cost was real (three `Score.slots()` rebuilds inside a per-slot loop, now zero — the only remaining callers are in `engine/`) but it is not the argument: three copies of a question can disagree about a word boundary and no test would notice.

**Finding worth keeping.** `before` ignores junctions while `after` blocks at them. That asymmetry is right — recitation ends forward at a stop, but the slot behind it was said — it is what all three copies did, and it was written down nowhere. **No gate distinguishes the two readings.** Making `before` block at junctions leaves all eight gates and every other test green. One test in `tests/test_neighbourhood.py` is now the only thing holding it, which is why it exists.

## 2. A pass list arriving by default

`build(reading, passes=None)` fell back to `canon.passes.LEXEME_PASSES`, so a riwayah that forgot to supply its own got a working pipeline that was silently not its own. `passes` is now required.

The fallback was already dead — `api.Recitation.build` always passes `self.passes`, and the only callers that omitted it were two ledger tests. No `BuildProfile`: `passes` is still the only per-riwayah build knob, so there is nothing for one to carry.

## 3. `Scribe` keyed on `id()`

The one that was not taste. Grapheme→slot edges were recorded against `id()` of a mutable draft. A pass that dropped a draft took the key out of `ordinals` with it, `_slot` returned `None`, and the edge was discarded without a word.

Measured over the corpus, both scripts:

| | |
|---|---|
| edge lookups | 1,283,790 |
| silent misses | **188**, in 30 verses |
| `id()` reuse hits | 0 |

Every one of the 30 is a muqattaat opening, where `canon/spell.py` replaces a word's drafts with the spelled letter names. They were harmless only because that pass re-evidences what it splices in, so the loss and the replacement cancelled. A written character anchored to no sound is invisible in output and invisible to the attestation gate, which by construction reads the links that survived — so a genuine loss had 188 pieces of noise to hide in.

`_Draft` now carries a `uid` minted at creation, `assemble` keys ordinals on it, and a miss raises `OrphanedEdgeError` naming the verse, the offset and the draft. `spell_muqattaat` says what happens to the edges it invalidates — `Scribe.withdraw(span)` — instead of orphaning them.

An ordinal would not have worked as the identity: ordinals are assigned in `assemble` from the surviving list, so they do not exist while the passes that reorder, splice and drop drafts are running.

Two defects fall out of the same field. `list.remove` and `list.index` compared `_Draft` by value, so `spell.py`'s splice could have landed at an identical draft in an earlier word; and a freed `id()` can be reused by a draft created later in the same build, pointing an edge at the wrong slot rather than at none. Neither was firing — reuse measured zero — and neither can now.

## 4. The 27 `del`s, counted

Item four was left open as a preference: is a pass's visible dependency list worth 27 `del` statements, or should the five-object signature collapse into a context object. **Counting them settles it, and the count was available the whole time.** The 27 were never one number:

| | signature | count | where |
|---|---|---|---|
| A | `Classifier.look(near, plan, at, boundaries)` — *four* | 16 | `rules/` ×7 modules |
| B | `LexemePass(reading, drafts, lexicon, scribe, selection)` | 4 | `canon/passes.py` ×2, `spell.py`, `khilaf.py` |
| C | `derivation(context)` | 2 | `derive/length.py`, `derive/wasl.py` |
| D | **no protocol at all** | 5 | `engine/run.py` ×2, `laws.py`, `derive/lexeme.py`, `rules/boundary.py` |

Only four were the signature the question named. The largest group is a *four*-parameter protocol, where a context object buys one line per implementation and costs the dependency list. Group D was dead code: `perform` built `index = {slot.id: slot for slot in slots}` for the sole purpose of handing it to `_materialise`, which deleted it, and `relengthened(nucleus)` ignored its only argument and returned `Long(Quality.A)` unconditionally — a call shaped like a transform that transformed nothing.

Doc 05 also argued `del` beats "a linter suppression that would hide it". There is no linter here to suppress; nothing flagged an unused parameter either way.

## 5. The real defect: the convention was not applied

```
canon/passes.py:141: _apply_allah_lexeme ignores ['selection'] without saying so
canon/passes.py:196: _apply_pausal_lexemes ignores ['scribe', 'selection'] without saying so
```

Two of the five lexeme passes ignored parameters in silence, so "no `del`" meant either "reads all of them" or "the author forgot", with nothing to tell them apart.

`structure_lint`'s new `signature-honesty` check closes it. An implementation is recognised by its **parameter names** rather than its own name, so it stays correct as passes are added; a Protocol's `...` body is skipped, since it declares parameters and by construction reads none. **25 implementations checked, 0 problems.**

`LexemePass` also stops being `Callable[[Reading, list, object, object, object], None]` — three `object`s type-check nothing, which is most of why the signature read as arbitrary — and becomes a `Protocol` with names and types. The `=None` defaults go with it: `build` supplies all five on every call, so a default advertised an optionality no caller has and let an implementation drift out of the protocol silently.

Final count **23**: 16 classifier, 5 pass, 2 derivation. Every one verified.

## Gates

No output moves, and for items 1–3 the stronger claim is available: the `Inscription` is **byte-identical across the whole corpus in both scripts — 1,322,678 spellings, same digest**.

| gate | before | after |
|---|---|---|
| cross word / verse | 99.997 / 100.000 | 99.997 / 100.000 |
| regression word / verse | 99.928 / 97.674 | 99.928 / 97.674 |
| roundtrip uthmani | 100.000 | 100.000 |
| attest uthmani / indopak | 178 / 239 | 178 / 239 |
| l1 residue | 18 | 18 |

No floor moved. Suite 267 → 281 passing, `comment_lint` 0 problems in 92 files, `structure_lint` 0 problems in 63 files.

**Falsifiers, run by hand:**
- Removing `Scribe.withdraw` from the muqattaat pass makes `2:1` raise `OrphanedEdgeError` at offset 0 — the path that used to swallow 188 edges.
- Making `before` block at junctions passes every gate and every pre-existing test, and fails only the new test. That result is the reason the test is there.
- Dropping `scribe` from `connect_plural_meem`'s `del` line is named at `passes.py:174`.
- Restoring the two defects §5 fixed is named three times, once per silently ignored parameter — so the check catches the exact defect that was live, not a hypothetical one.
- `_materialise` still raises `MaterialisationError` on a half-merge with `index` gone, which is the only behaviour the group D deletions came near.

## Docs

`docs/design/05` is archived rather than closed as "no change", with its mistaken paragraph left in place and marked. The pattern is worth keeping: a document can call an item pure preference because it has not counted it. `docs/adr/011`'s forward reference to the open item is marked, not rewritten.

`cross_word_noon` returning a role name rather than the slot it created was listed under 05 but goes to 08, where `requires` is: the builder greps the role name, so a script fact decides a canonical question.

## Noted, not fixed

- **Group C's two `del context`s stay.** `hamzat_wasl` declares 13 `requires` and reads zero; `pausal_length` declares 9 and reads zero. That is design question 08's problem — ADR-010 already records why `requires` is a hand-kept proxy — and the `del` is a symptom, not the thing to fix.
- `signature-honesty` keys on parameter-name tuples, so an implementation that renames a parameter silently stops being checked. A registry of protocol signatures is more machinery than two protocols justify.
- `Scribe.withdraw` is called only where a pass drops drafts today. Nothing checks that a *future* draft-dropping pass calls it — the raise is the backstop, not a lint.
- The `uid` counter is process-wide and monotonic, so `_Draft` equality is now identity in practice. Nothing relied on value equality except the two `list.index`/`remove` sites, which wanted identity anyway.
- The two dangling doc links (`docs/README.md` → `mualem_conversion.md`, `docs/hafs/silent-letter-audit.md` → `tokenization-reconciliation.md`) still predate this branch.