### PR TITLE
Design a minimal relational projection surface

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ point in time and stays true whatever the code does next.
 
 ## Current references
 
+- [projection-redesign.md](projection-redesign.md) — legacy audit, model gaps,
+  the two-projection target, and its Uthmani delivery plan.
 - [domain-facts.md](domain-facts.md) — the reading facts the package encodes.
 - [mualem_conversion.md](mualem_conversion.md) — the Mualem notation mapping.
 - [hafs/](hafs/) — the public projections: tajweed, letter-phoneme and

--- a/docs/adr/010-public-projections.md
+++ b/docs/adr/010-public-projections.md
@@ -1,0 +1,193 @@
+# ADR-010: One relational trace beside the phoneme stream
+
+Status: **proposed**. Uthmani/Hafs is the first contract; IndoPak is explicitly
+deferred.
+
+## Context
+
+The legacy API exposed five answers to one question: phonemes, flat
+letter/phoneme groups, character cells, Tajweed mappings, and silent flags.
+Each non-phoneme view walked the mutable mapping again. That produced useful
+application behaviour, but also several places to redistribute waqf vowels,
+shortened carriers, assimilated letters, the Allah dagger alif, and expanded
+muqattaat.
+
+The replacement model already contains the facts those views inferred:
+`Inscription` records source graphemes and canonical relationships;
+`Performance` records sounds, silence, insertion, mergers and their causes;
+and `Score` is their stable join. Publishing those internal objects is not a
+public API, but publishing another cell DTO for each use case would recreate
+the legacy disagreement.
+
+## Decision
+
+There are **two public projections**:
+
+1. **`phonemes`** — the ordered token stream, optionally partitioned by word.
+2. **`trace`** — one normalized relational description of source writing,
+   canonical anchors, performed sounds, transformations and Tajweed
+   occurrences.
+
+Silent flags, letter animation groups, character cells, Tajweed-coloured
+script, recited Arabic, MFA timing attachment and Inspector rows are **queries
+or serializers over `trace`**, not additional semantic projections.
+
+This is not one giant nested cell tree. `trace` is a small set of tables joined
+by opaque IDs. A grapheme, realization, sound and occurrence is stored once
+even when applications join them differently.
+
+## Normative shape
+
+Names remain provisional until the schema spike, but these cardinalities and
+ownership rules are the decision.
+
+```python
+Trace(
+    ref, script,
+    boundaries: tuple[WordBoundary, ...],
+    graphemes: tuple[ProjectedGrapheme, ...],
+    anchors: tuple[Anchor, ...],
+    realizations: tuple[Realization, ...],
+    sounds: tuple[ProjectedSound, ...],
+    occurrences: tuple[ProjectedOccurrence, ...],
+)
+```
+
+### Graphemes
+
+Every Unicode scalar in the selected Uthmani source appears exactly once,
+including spaces, stop signs, verse marks, madd signs and silence signs.
+
+```python
+ProjectedGrapheme(
+    id, char, source_index, word,
+    kind,                         # base/haraka/tanween/shadda/carrier/mark/structural
+    anchors: tuple[AnchorId, ...],
+)
+```
+
+`kind` is coarse orthographic identity, not a claim about audibility. A carrier
+is not necessarily long or sounding. `source_index` is for source slicing;
+transformed output never uses it as its join key.
+
+### Anchors
+
+An anchor is the public, script-neutral address of one aspect of one canonical
+slot:
+
+```python
+Anchor(id, word, ordinal, aspect)       # aspect = onset | nucleus
+```
+
+It keeps final-vowel deletion distinct from an onset while hiding the internal
+`Slot` vocabulary. One grapheme may show several anchors (tanween), several
+graphemes may show one anchor (haraka plus carrier), and an inserted
+realization may have an anchor without a grapheme.
+
+### Realizations
+
+`Realization` is the only public cross-layer edge:
+
+```python
+Realization(
+    id,
+    anchors: tuple[AnchorId, ...],
+    graphemes: tuple[GraphemeId, ...],
+    sounds: tuple[SoundId, ...],
+    produced_by: OccurrenceId,
+    effect,       # realize | merge | delete | insert | replace | shorten
+    role,         # host | contributor
+)
+```
+
+Lists may be empty only where the domain requires it: unwritten material has
+no grapheme; silence has no sound; and only the already-admitted slot-less
+insertion has no anchor. `effect` is a closed presentation vocabulary derived
+mechanically from attribution and canonical/performed state. It does not name
+a rule. `produced_by` supplies the exact reason, so there is no parallel
+`SilenceReason` enum.
+
+`role` retains both sides of idgham and other shared sounds without choosing a
+UI policy. An animator may light the host only or every contributor.
+
+### Sounds
+
+```python
+ProjectedSound(id, index, word, token, features)
+```
+
+`index` is utterance-global and total. `word` is performance ownership, so a
+cross-word merger belongs to its host word. MFA timestamps attach to
+`SoundId`/`index`, never to a letter entry. Word-local indices are a convenience
+serializer, not authoritative identity.
+
+### Occurrences
+
+```python
+ProjectedOccurrence(
+    id, rule, family,
+    participants: tuple[Participant, ...],
+    realizes: tuple[RealizationId, ...],
+)
+Participant(anchor, role)              # trigger/source/target/carrier/host
+```
+
+Occurrences are exhaustive, including plain and classification-only rules.
+Participant roles are closed and family-checked. This is the information
+needed by error correction and granular Tajweed colouring: which canonical
+positions participated, what each did, and which graphemes and sounds they
+reach.
+
+A production edge has one cause, while madd, tafkheem and other classifiers
+may overlap it. Those classifiers use the occurrence-to-realization join; they
+are not squeezed into `Realization.produced_by` or a one-tag cell.
+
+## Query recipes, not new contracts
+
+| Application answer | Query over `trace` |
+|---|---|
+| silent flag | grapheme has no sounded realization; also return deleting occurrence |
+| phoneme/letter co-highlight | sound → realizations → host and contributor graphemes |
+| one preferred animated letter | choose host graphemes as an explicit UI policy |
+| letter timing | union timestamp intervals for its sounded realizations |
+| silent-letter timing | use a merger host; otherwise adjacency is an explicit client policy |
+| Tajweed on letters | occurrence → participants/realizations → anchors → graphemes |
+| Tajweed on phonemes | occurrence → realizations → sounds |
+| coloured Quran text | assign all overlapping occurrences to source-ordered graphemes |
+| Inspector cells | group graphemes/virtual insertions by word, anchor and kind |
+| recited Arabic | serialize realizations under a named writing preset |
+| letter-level MFA labels | group contiguous sounds by a declared anchor policy |
+
+Helpers for these recipes may ship, but contain no detector or second semantic
+snapshot.
+
+## Rejected alternatives
+
+* **Four atomic mapping projections:** silence, Tajweed, ownership and writing
+  are slices of one many-to-many relation; separate DTOs duplicate IDs and
+  disagree on boundary transformations.
+* **Character cells as the sole projection:** cells are a useful presentation
+  model, but one tag loses overlaps, source and virtual characters mix, and
+  `share_group` hides a many-to-many edge.
+* **Publish `Score`, `Inscription`, `Performance`:** this couples consumers to
+  engine vocabulary and internal redundancy.
+* **Nest everything below words/cells:** cross-word occurrences and shared
+  sounds would be duplicated or parent-dependent. A convenience serializer
+  may nest references; the normative schema remains normalized.
+
+## Compatibility and scope
+
+Legacy outputs are migration oracles, not new contracts. Adapters may recreate
+them from `trace` while migrating. IDs are opaque and request-scoped. Enum
+additions are additive within a schema major version; changed field meaning is
+breaking. Ordering is normative only where documented.
+
+The first release supports Uthmani/Hafs. The schema avoids glyph-specific
+assumptions, but IndoPak is not an acceptance gate.
+
+## Consequences
+
+Consumers wanting phonemes get a tuple. Every richer application pays for one
+trace and chooses grouping and visual priority without re-running domain
+logic. Before acceptance, the implementation must complete occurrence
+participants, classification joins and orthographic non-sounding edges.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ Read in order. 001–006 are the design; 007 is how it is laid out in code;
 | [007](007-package-and-conventions.md) | Package tree, module boundaries, data schemas, naming |
 | [008](008-conformance-and-phases.md) | Invariants, fixtures, the L1 harness, the reversal trigger, phase order |
 | [009](009-the-output-alphabet.md) | The output alphabet as entries plus composition, and what replaced row-count totality |
+| [010](010-public-projections.md) | One relational trace beside the phoneme stream |
 
 ## What this is for
 

--- a/docs/design/03-canonical-vocabulary.md
+++ b/docs/design/03-canonical-vocabulary.md
@@ -1,94 +1,96 @@
-# 03 - The canonical vocabulary, before projections fix it
+# 03 - Canonical vocabulary resolved before projections
 
-Status: **open**, and time-boxed. Audit: "Modelling, before projections become
-a contract".
+Status: **resolved as a design decision**. Implementation is scheduled before
+ADR-010 is accepted. Audit: “Modelling, before projections become a contract”.
 
-## Why this one has a deadline
+## Why this had a deadline
 
-A `Slot` is what a projection projects. Once `anchored`, the mualem view and
-the tajweed mapping are public, `Onset` and `SlotOrigin` are in a consumer's
-`match` statement and changing them is a breaking release. Every other
-document on this list can wait; this one gets more expensive on a schedule.
+A `Slot` is what a projection ultimately anchors. Once internal vocabulary
+leaks into consumers' match statements, changing it becomes a breaking release.
+The projection audit makes the boundary clear: the public trace exposes anchor
+aspect, realization effect, lexical relationships and occurrences—not these
+internal storage types.
 
-The audit rejected refactoring `SlotOrigin` on the grounds that no audited
-Warsh case needs two of its axes at once. That rejection is about *urgency*,
-not about correctness -- the enum is still answering three questions. What
-follows is the decision that rejection deferred.
+## Decisions
 
-## The three
+### Split `Onset` into manner and presence
 
-### `Onset`
+`PLAIN`, `GEMINATE` and `TASHIL` describe articulation. `WASL` and `SILAH`
+describe boundary-conditional presence. They are independent questions, and
+one enum forbids combinations without a cross-riwayah domain reason.
 
-`PLAIN`, `GEMINATE`, `TASHIL` describe how the consonant is articulated.
-`WASL`, `SILAH` describe whether it is there and what connects it. Two
-orthogonal axes in one field, so the model cannot state "geminate and wasl"
-even though nothing in the domain forbids the combination.
+`Slot` will instead carry:
 
-Options: split into `manner` and `presence`; or keep one enum and document the
-combinations as genuinely impossible. The second is defensible only if someone
-establishes that they *are* impossible -- across riwayat, not just in Hafs.
+* `onset_manner`: plain, geminate or tashil; and
+* `onset_presence`: always, when-started or when-connected.
 
-### `SlotOrigin`
+Waṣl is `when-started`; the exceptional onset-silah site is
+`when-connected`. Rules then inspect only the axis they mean. The public trace
+does not expose either enum; it exposes the resulting anchor/realization.
 
-`WRITTEN`, `SPELLED`, `NUNATION`. Three questions: did the script write it,
-is it part of a spelled letter name, did it come from tanween. `WRITTEN`
-carries no information -- it means "none of the others". A slot cannot be both
-spelled and nunation, and no domain fact says it may not be.
+### Replace `SlotOrigin` with provenance membership
 
-Both `rules/boundary.py` and `rules/noon_sakinah.py` branch on this, and the
-round-trip digest hashes it, so it is load-bearing. That makes it a
-decomposition, not a deletion: three booleans, or a small set, or two fields.
+`WRITTEN` means “neither of the other values” and says nothing: script
+writtenness lives in `Inscription.Spelling`. Existing branches ask either “is
+this nunation?” or “is this part of a spelled letter name?”.
 
-### `Annotation`
+Replace the enum with an independent provenance set whose closed members are
+`SPELLED` and `NUNATION`; ordinary slots use the empty set. Membership permits a
+future combination without claiming Hafs contains one. Update round-trip
+digests and every call site from enum equality to the question it asks.
 
-Documented as "changes no sound". `DIVINE_NAME` changes sound, through
-`rules/tafkheem.py:136`. Either the documentation is wrong, or `DIVINE_NAME`
-is not an annotation.
+### Replace `Annotation` with lexical class and processes
 
-The cheap reading -- rewrite the docstring -- is the wrong one. The stated
-invariant is what lets a projection ignore annotations when computing
-phonemes. If it does not hold, the type name is doing no work, and the honest
-rename is `SlotTag`: a tag a slot carries, with no promise about sound.
+The claim that `Annotation` changes no sound is false. `DIVINE_NAME` is read by
+tafkheem, and `IMALA`/`ISHMAM` are read by the classifier to create named
+realizations or occurrences.
 
-`IMALA` staying an `Annotation` after moving out of `Quality` was judged
-correct: the named process persists whichever vowel the khilaf selects. That
-judgement does not extend to `DIVINE_NAME`.
+Delete the container, not the facts:
 
-### `PausalLong` and `Silah`
+* `DIVINE_NAME` becomes an optional lexical class on the slot/lexeme; and
+* `IMALA` and `ISHMAM` become members of a recitation-process set.
 
-Both are `Nucleus` kinds. Both are statements about a boundary -- what this
-vowel becomes when the reciter stops, what a pronoun vowel does before a
-consonant. Wearing a nucleus kind makes them look like inherent length.
+Imala remains attached regardless of which vowel quality a khilaf selects. The
+public trace exposes the lexical relationship and resulting occurrences, not a
+misleading sound-neutral tag collection.
 
-Open: whether the boundary fact belongs on the slot at all, or whether the
-nucleus should be plain and the boundary rule should produce the length. The
-second is cleaner and much larger; `engine/run.py` `_plain_sound` already
-reads a `Relength` override, so the machinery exists.
+### Retain `Silah` and `PausalLong` nuclei
 
-## What to audit before deciding
+These are boundary-conditional canonical functions, not cached outcomes.
+`Silah` is long when connected and absent at pause; `PausalLong` is short when
+connected and long at pause. A boundary-free Score must state which function a
+plan will resolve. Flattening to a plain nucleus would move lexical knowledge
+into a detector and force recited writing to reconstruct it. `Relength`
+performs the selected branch; it does not make the conditional fact redundant.
 
-1. **Enumerate the impossible combinations.** For `Onset`, every
-   manner-presence pair, marked possible or impossible with a domain reason.
-   A pair that is impossible only in Hafs is possible.
-2. **Count the branches.** Every `match` and `is` on `SlotOrigin` in `rules/`
-   and `render/`, and which of its three questions each one is asking. If
-   every branch asks one question, the decomposition is mechanical.
-3. **Audit `Annotation` members against sound.** For each, does any rule read
-   it and emit a different sound. `DIVINE_NAME` is known; establish whether it
-   is alone.
-4. **Check `PausalLong` against the boundary plan.** Whether a `PausalLong`
-   nucleus is ever correct at a slot the plan does not stop at. If it never
-   is, it is a boundary fact and the nucleus kind is a cache.
+## Audit findings
 
-## Ordering
+1. Current `Onset` consumers ask either manner (`GEMINATE`, `TASHIL`) or
+   presence (`WASL`, `SILAH`). No branch requires the mixed union.
+2. `SlotOrigin` consumers ask either nunation (boundary/writing) or spelled
+   expansion (muqattaat/noon). No consumer positively needs `WRITTEN`.
+3. Every current `Annotation` member participates in classification or sound;
+   the sound-neutral invariant cannot be repaired with a docstring tweak.
+4. Conditional nuclei are correct before choosing a boundary plan: the plan
+   selects a branch but does not create the lexical fact.
 
-`Annotation` first: smallest, and the answer is forced once the census is
-done. `Onset` second. `SlotOrigin` third. `PausalLong`/`Silah` last, and only
-if 4 shows the redundancy is real.
+## Migration order
+
+1. Split `Annotation`, updating digest and classifier fixtures.
+2. Replace `SlotOrigin`, updating serialization, rules, writing and muqattaat
+   fixtures.
+3. Split onset manner/presence, updating triggers and conflict keys.
+4. Keep conditional nuclei and test both outcomes under distinct plans.
+
+This work precedes freezing `trace`, but replacement types remain internal.
 
 ## Acceptance
 
-- Every `Slot` field answers one question.
-- No enum member means "none of the others".
-- Any type documented as sound-neutral is sound-neutral, checked by a test
-  that renders with and without it.
+* Every `Slot` field answers one question.
+* No enum member means “none of the others”.
+* No type claims sound-neutrality while a sound/classification rule reads it.
+* Wasl/silah and manner combinations are representable without enum growth.
+* Both conditional nucleus outcomes are tested from the same Score under two
+  plans.
+* Projection fixtures preserve the same anchors, realizations, sounds and
+  occurrences through the migration.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,7 +18,7 @@ measured before choosing, and what would make the decision wrong.
 | | Question | Blocks |
 |---|---|---|
 | [01](01-mark-semantics.md) | Does a script inventory hand downstream code a typed fact or a string? | Warsh |
-| [03](03-canonical-vocabulary.md) | Do `Onset`, `SlotOrigin` and `Annotation` split? | projections |
+| [03](03-canonical-vocabulary.md) | Resolved: split onset axes, provenance, and annotation concerns | projections |
 | [04](04-data-schemas.md) | What does a data file have to say about itself before it is trusted? | Warsh |
 | [05](05-build-internals.md) | Who owns slot adjacency, pass order, and slot identity? | nothing yet |
 | [06](06-seen-sad-khilaf.md) | How is the seen/sad khilaf authored and selected? | correctness today |

--- a/docs/projection-redesign.md
+++ b/docs/projection-redesign.md
@@ -1,0 +1,237 @@
+# Public projection redesign: legacy audit and delivery plan
+
+This document turns the legacy evidence into a delivery plan for **Hafs,
+Uthmani script**. Legacy applications test information sufficiency; they do
+not dictate the public shape. IndoPak projection work is deferred.
+
+## Executive conclusion
+
+Ship the smallest useful surface:
+
+* retain **phonemes** as the direct fundamental projection;
+* add one lossless **relational trace** joining writing, canonical anchors,
+  performed sound, transformations and Tajweed occurrences; and
+* implement cells, silence, timing groups, letter maps, recited writing and
+  coloured text as helpers/serializers over that trace.
+
+This is two projections but only one rich schema. It preserves arbitrary
+many-to-many relationships instead of baking the Inspector's grouping or a
+teleprompter's preferred highlight into domain data.
+
+## 1. Legacy projection audit
+
+### Flat letter/phoneme mappings
+
+The flat view guaranteed non-empty phoneme groups and absorbed silent letters
+into a neighbour. It was convenient for aligner labels and animation: spaces
+encoded boundaries, extensions were split, and silence merged PREV, NEXT or
+across words.
+
+That linear tape erased the reason a letter was silent, made merge direction a
+policy, used source strings as keys, redistributed waqf-tanween and iltiqa
+sounds, special-cased muqattaat, and failed the “one sounding grapheme” premise
+for idgham shafawi.
+
+**Retain:** sound order, word ownership, MFA grouping and every contributor.
+**Retire:** non-empty entry invariants, embedded spaces, PREV/NEXT and
+redistributed presentation ownership as canonical facts.
+
+### Silent flags
+
+The boolean view existed because flat groups did not identify their silent
+members. The audit found continuing tanween alif/maqsura without an explaining
+tag, context-dependent silah extensions, and idgham-shafawi cases where a flag
+alone could not drive co-highlighting.
+
+**Retain:** explicit absence with a typed cause and the relation from an
+assimilated letter to its host sound. **Retire:** a separate truth source and
+inference from Tajweed tag names.
+
+### Tajweed mappings
+
+The per-letter view usefully distinguished source and target rules and allowed
+overlaps. It still reconstructed rules after phonemization and faced unstable
+placement questions: madd on carrier/base, qalqala on echo/consonant, tafkheem
+on vowel/consonant, synthetic Allah dagger alif and muqattaat overrides.
+
+**Retain:** occurrence identity, exact rule, typed participants, grapheme and
+sound reachability, overlaps and boundary context. **Retire:** parallel rule
+vocabulary, post-hoc detection and placement priority hidden in a serializer.
+
+### Character cells
+
+This was the most mature legacy view. One source or implicit unit carried
+role, status, phonemes, indices, a tag, share group and source-letter indices.
+Its useful requirements are:
+
+* every scalar is addressable and source-ordered;
+* implicit units and transformations are visible;
+* several marks may share one timing interval;
+* one written unit may reach several sounds; and
+* provenance survives spelling expansion.
+
+Its debts must not become ontology. Cells mix source scalars with empty-string
+virtual cells; duplicate word-local phoneme indices; use `share_group` as a
+surrogate edge; lose overlaps through one `tag`; conflate orthographic role
+with performance status; and compose shadda into source `chars` for a renderer.
+
+The trace can reproduce cells; cells cannot reproduce the trace without these
+special conventions.
+
+## 2. Consumer sufficiency
+
+### Inspector
+
+Inspector needs source-order scalars, virtual writing, roles, replacements,
+silence reasons, merger contributors/hosts, ordered sounds and every Tajweed
+rule on both writing and sound. The trace supplies all of them. Grey, underline,
+co-highlight and colour priority remain explicit presentation choices.
+
+### Timestamp shards and teleprompter
+
+Forced-alignment timestamps belong to performed sounds. Joining by `SoundId`
+avoids choosing which duplicated cell owns a long vowel. Realization edges give
+all co-highlighted graphemes; merger roles allow either host-only or all-letter
+animation. A purely orthographic silent mark has no natural timestamp, so
+adjacency/duration synthesis must remain an animator policy.
+
+### Letter-level MFA
+
+MFA needs a linear label stream although the domain is a graph. A helper can
+coalesce ordered sounds by a declared host/contributor policy and return trace
+IDs with its labels. Alignment then joins back without matching Arabic strings.
+
+### Future colouring and correction
+
+Granular colouring requires overlapping occurrences, not a winning tag. Error
+correction requires rule identity/family, participant roles, expected sound
+features and written targets. The same joins provide these without an
+error-correction projection. Madd counts, selected duration and cause must be
+structured semantics rather than parsed from names or tokens.
+
+## 3. Current model readiness
+
+### Present foundations
+
+* Distinct grapheme, slot, sound and occurrence IDs prevent cross-domain key
+  confusion.
+* `Spelling` retains evidence, attestation, decoration and structural writing.
+* `Attribution` distinguishes hosting, insertion, merger contribution and
+  silence.
+* Every attribution names an occurrence, so its cause is recoverable.
+* `Aspect` preserves onset/nucleus ownership.
+* Variant selection and boundary plan travel with the produced performance.
+
+### Gaps before a public contract
+
+1. **Orthographic zero is not performance silence.** Seats, otiose carriers,
+   madd signs and decorations may lack a slot attribution. Trace construction
+   needs a total grapheme row and explicit orthographic contribution, not only
+   `render.anchored()`'s performed `Silent` rows.
+2. **Participants lack roles.** The current tuple cannot say trigger, source,
+   target, host, carrier or affected vowel. Define family-specific variants.
+3. **Classification overlaps need a join.** A production attribution has one
+   `by`, while madd, tafkheem and tarqeeq can classify its realization too.
+4. **Anchoring over-collects marks.** Current `Decorates`/`Attests` lookup can
+   attach a mark to either aspect. Highlight-self, highlight-anchor and
+   evidence-for-rule are separate relations and must be defined.
+5. **Inserted writing differs from inserted sound.** An unwritten helping
+   vowel can have a slot; the 3:1 repair is slot-less. Only renderers invent
+   display glyphs.
+6. **Effects need mechanical definitions.** `replace` and `shorten` are useful,
+   but must derive from canonical/performed state rather than string tests.
+7. **Madd detail is incomplete for correction.** Add cause and
+   permitted/selected duration semantics, with the evaluated realization.
+8. **Order and ID scope need contracts.** Define cross-word merger, structural
+   grapheme and slot-less-insertion order plus deterministic serialization.
+9. **Recited writing remains derived.** Expose deletion/virtual edges so
+   ADR-005 presets never become join keys or stored layers.
+10. **Design 03 awaits implementation.** Keep its internal vocabulary out of
+    the public trace while applying its resolved decomposition.
+
+## 4. Uthmani knowledge checklist
+
+The spike needs joined, stopped and started examples where applicable:
+
+| Family | Relationships that must be representable |
+|---|---|
+| short/long vowel | base, haraka, carrier fan-in; shared timing without duplicate sound |
+| silent carriers | otiose alif/waw/ya/maqsura, silence signs and typed cause |
+| hamzat al-wasl | source, start vowel, joined deletion, repair and article lam |
+| tanween | one mark to vowel+nun; continuing alif silence; waqf iwad carrier |
+| silah | written/virtual extension, joined length and pausal deletion |
+| Allah | lexical class, heavy/light lam, virtual/written dagger alif, waqf change |
+| mergers | within/cross-word source, host, shared sound, complete/partial forms |
+| noon/meem | trigger/source/target roles and nasal placement for noon/tanween |
+| madd | haraka/carrier/mark, subtype, cause, counts and boundary change |
+| qalqala | closure/release, one occurrence, consonant and stop degree |
+| emphasis | consonant and governed vowel reach; raa and divine-name cases |
+| muqattaat | compact glyph to spelled anchors/sounds/rules without cached mapping |
+| waqf endings | vowel deletion, ta marbuta, iwad, arid/leen and qalqala |
+| ibtida | start boundary, wasl vowel, gemination and right context |
+| marks | imala, ishmam, tashil, sakt, seen/sad, iqlab, maddah and advice |
+| slot-less repair | side/order, virtual edge, occurrence, sound and rendered form |
+
+An unmodelled row blocks the contract; serializers may not repair it.
+
+## 5. Trace invariants
+
+1. Concatenated source graphemes exactly reproduce the input.
+2. Every grapheme appears once and is anchor-linked or orthographic-only.
+3. Every sound appears once in performance order and has a realization.
+4. Every realization has one production occurrence and all IDs resolve.
+5. Every deletion has no sound and a non-plain cause.
+6. Every merger exposes contributor and host reaching one sound/occurrence.
+7. Every insertion has an anchor or explicit side-of-anchor placement.
+8. Every occurrence exposes typed participants and affected realizations,
+   including classification-only occurrences.
+9. No projection runs detectors, derives semantics from output tokens or
+   chooses a visual priority.
+10. Nested serializers round-trip to the same normalized trace and IDs.
+
+## 6. Delivery plan
+
+### A. Evidence and schema spike
+
+1. Extract representative legacy rows and full-corpus counts for every family.
+2. Build an internal normalized trace over Score/Inscription/Performance.
+3. Recreate legacy cells, Tajweed maps, silence and letter groups from it.
+4. Classify mismatches as retired presentation policy or internal knowledge
+   gaps; fix the latter below projections.
+
+### B. Model completion
+
+1. Add family-typed participants and occurrence/realization coverage.
+2. Make orthographic-only contribution total.
+3. Define the closed transformation derivation table.
+4. Add structured madd duration/cause semantics.
+5. Implement design 03's vocabulary resolution.
+
+### C. Contract and helpers
+
+1. Accept ADR-010 with concrete Python/JSON schema, ordering, evolution and
+   errors.
+2. Ship `phonemes()` and `trace()`.
+3. Add non-normative indices for grapheme, sound and occurrence; timing
+   attachment; and source/recited-writing serializers.
+4. Keep legacy adapters only through migration and label their grouping and
+   colour priorities as legacy policy.
+
+### D. Gates
+
+Run full-corpus continuous, verse-edge, word-edge, targeted waqf and ibtida
+traversals. Require invariants, baseline explainability, deterministic JSON
+round-trip and a consumer fixture recreating Inspector/timestamp joins without
+importing `canon`, `rules` or `engine`.
+
+## 7. Non-goals and checkpoints
+
+Non-goals are IndoPak parity in the first implementation, a universal UI cell,
+fabricated silent timing, public internal dataclasses, and preservation of
+legacy whitespace/merge-direction/empty-cell/single-tag conventions.
+
+The spike has three schema questions: exact participant roles by family,
+whether transformed Arabic returns virtual glyph records or a string plus
+references, and whether sound features are always included or opt-in. None
+requires another top-level projection. The number remains two unless a fact
+cannot be queried without rerunning domain logic.


### PR DESCRIPTION
### Motivation

- Provide a concise, application-agnostic projection design that replaces the scattered legacy projections with a minimal public surface suitable for Inspector, animator/timestamp use, MFA alignment, Tajweed colouring and future correction workflows.
- Audit the existing letter↔phoneme, silent, Tajweed and character-cell views to identify which facts must be preserved, which presentation conventions should be retired, and what canonical/model gaps need closure before a public contract is frozen.
- Resolve an outstanding modelling decision in the canonical vocabulary so the public projection contract does not leak internal union/enum limitations into consumers.

### Description

- Add `docs/adr/010-public-projections.md` which proposes two public projections: `phonemes` (ordered token stream) and `trace` (a normalized relational trace joining source graphemes, anchors, realizations, sounds and occurrences), with a normative sketch of the schema and query recipes over the trace.
- Add `docs/projection-redesign.md` containing the legacy audit, delivery plan, Uthmani checklist, trace invariants, non-goals, and phased implementation and gating plan for shipping the new projections for Hafs/Uthmani.
- Update `docs/design/03-canonical-vocabulary.md` to resolve item 03 by splitting `Onset` into independent manner/presence axes, replacing `SlotOrigin` with provenance membership, and replacing the `Annotation` container with an explicit lexical/process split while retaining conditional nuclei (`Silah`/`PausalLong`) as canonical facts.
- Update documentation indices (`docs/README.md`, `docs/adr/README.md`, `docs/design/README.md`) so the new ADR and redesign docs are discoverable and the design status is reflected.

### Testing

- Ran `git diff --check` to ensure no staged whitespace/index problems and it reported no issues.
- Ran project structure lint `python tools/structure_lint.py` which returned `0 problems in 63 files`.
- Ran the test suite with `pytest -q` and observed `249 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6989171afc8322b9caabb1195f962a)