### PR TITLE
docs: reconcile the public projection model

### DIFF
--- a/docs/adr/013-public-projection-foundations.md
+++ b/docs/adr/013-public-projection-foundations.md
@@ -36,7 +36,7 @@ schema edition that give the label its meaning.
 ### 2. Nodes do not absorb relations
 
 `Reading` publishes ordered node arrays for words, glyphs, units, sounds, and
-occurrences, plus three relation arrays:
+occurrences, plus four relation arrays:
 
 - `spellings` is the exact `Evidences | Attests | Decorates | Structural`
   union from ADR-003;
@@ -44,7 +44,15 @@ occurrences, plus three relation arrays:
   `Hosts | Inserted | MergedInto | Silent` union from ADR-002, including
   `Aspect`, insertion side, sound, and occurrence;
 - `modifiers` links an occurrence to each sound it recolours, relengthens, or
-  classifies without owning.
+  classifies without owning;
+- `contributions` links each non-structural glyph to the exact performance
+  edge or occurrence it presents, or marks it as orthographic-only.
+
+The contribution relation is necessary even though spelling and attribution
+are already present. A haraka, a length carrier, and a dagger can reach the
+same nucleus while presenting different performance outcomes. In particular,
+a carrier under a dagger can be orthographic-only while the dagger presents
+the long vowel. Unit audibility cannot decide glyph audibility.
 
 The serialized graph stores one direction for every relationship. Reverse
 indexes such as glyphs for a unit, sounds for a unit, rules for a sound, and
@@ -52,9 +60,9 @@ units for a word are named derived helpers. They are not duplicate facts in
 the wire format.
 
 No semantic `owner` is stored on a sound. Display ownership is a rendering
-policy over attribution aspect and spelling edges. This matters when the
-haraka and its carrier both evidence the same unit: choosing a unit cannot
-choose the glyph that should be painted.
+policy over attribution and contribution edges. This matters when the haraka
+and its carrier both evidence the same unit: choosing a unit cannot choose the
+glyph that should be painted.
 
 ### 3. Public values exclude invalid combinations
 
@@ -66,7 +74,9 @@ PausalLong(quality)`.
 It is not a nullable quality beside an independently set length. The `Onset`
 enum stays intact because the completed census found no domain state it cannot
 represent. Madd counts and durations are realization or teaching-policy data,
-not canonical facts, and are not added to `Unit`.
+not canonical facts, and are not added to `Unit`. A future duration contract
+must identify the transmission path or policy that makes permitted and
+selected counts authoritative.
 
 `RuleFamily` and execution phase are derived from `Rule` by total registries.
 They are not repeated on each occurrence. An occurrence retains its ordered,
@@ -90,10 +100,10 @@ class is currently consumed.
 ### 5. Recited writing is a derived view
 
 The core graph preserves source glyphs and domain relations. A recited-writing
-serializer may derive render glyphs from `write`, attributions, and insertion
-anchors. A slotless insertion is represented by its before/after anchor and
-its rendered sound; it is not forced into a fake unit or an empty source
-glyph.
+serializer may derive render glyphs from `write`, contributions, attributions,
+and insertion anchors. A slotless insertion is represented by its before/after
+anchor and its rendered sound; it is not forced into a fake unit or an empty
+source glyph.
 
 ## Consequences
 

--- a/docs/adr/013-public-projection-foundations.md
+++ b/docs/adr/013-public-projection-foundations.md
@@ -1,0 +1,107 @@
+# ADR-013: Public projections preserve the domain edges
+
+Status: accepted
+
+## Context
+
+ADR-005 deferred the public projection API. The projection audit established
+that the legacy APIs are four views of one graph. Two proposed replacements
+then exposed a real design choice:
+
+- a normalized graph preserves the model's typed relations, but needs an
+  explicit request envelope and a serious migration gate;
+- a convenient document supplies that envelope and gate, but flattening the
+  relations into arrays on nodes loses distinctions the domain requires.
+
+The loss is not theoretical. One grapheme may evidence different facts on
+several slots, an `Attests` edge is not an `Evidences` edge, and a structural
+grapheme belongs to no word. Likewise, a final consonant may realize its onset
+while its nucleus is silent at pause. A `sound` list on a unit cannot express
+that without recovering `Aspect` from the sound kind, which ADR-002 forbids.
+
+## Decision
+
+### 1. The public document is an identified snapshot
+
+`Reading` carries a schema version and the complete identity of the request:
+reference, riwayah, script, notation, canonicalized variant selection, boundary
+plan, and Score digest. Two documents are comparable only when those fields
+match.
+
+Array indices are request-local identifiers. The JSON contract does not call a
+bare integer or bare slot label stable. A durable address, if an API later
+needs one, must include the riwayah, canonicalized selection, Score digest, and
+schema edition that give the label its meaning.
+
+### 2. Nodes do not absorb relations
+
+`Reading` publishes ordered node arrays for words, glyphs, units, sounds, and
+occurrences, plus three relation arrays:
+
+- `spellings` is the exact `Evidences | Attests | Decorates | Structural`
+  union from ADR-003;
+- `attributions` is the exact
+  `Hosts | Inserted | MergedInto | Silent` union from ADR-002, including
+  `Aspect`, insertion side, sound, and occurrence;
+- `modifiers` links an occurrence to each sound it recolours, relengthens, or
+  classifies without owning.
+
+The serialized graph stores one direction for every relationship. Reverse
+indexes such as glyphs for a unit, sounds for a unit, rules for a sound, and
+units for a word are named derived helpers. They are not duplicate facts in
+the wire format.
+
+No semantic `owner` is stored on a sound. Display ownership is a rendering
+policy over attribution aspect and spelling edges. This matters when the
+haraka and its carrier both evidence the same unit: choosing a unit cannot
+choose the glyph that should be painted.
+
+### 3. Public values exclude invalid combinations
+
+The public nucleus is a discriminated value:
+
+`Silent | Short(quality) | Long(quality) | Silah(quality) |
+PausalLong(quality)`.
+
+It is not a nullable quality beside an independently set length. The `Onset`
+enum stays intact because the completed census found no domain state it cannot
+represent. Madd counts and durations are realization or teaching-policy data,
+not canonical facts, and are not added to `Unit`.
+
+`RuleFamily` and execution phase are derived from `Rule` by total registries.
+They are not repeated on each occurrence. An occurrence retains its ordered,
+role-labelled participants; ownership, insertion, merger, silence, and
+modification stay on the relation whose meaning they define.
+
+### 4. Lexical identity is not a recitation process
+
+The pending canonical-vocabulary change is amended:
+
+- `DIVINE_NAME` becomes a word-level `LexemeClass`;
+- `IMALA` and `ISHMAM` are rule occurrences and are not unit tags;
+- `SlotOrigin` still decomposes into the independent `nunation` and `spelled`
+  facts;
+- `SILAH` and `PAUSAL_LONG` remain conditional nucleus kinds.
+
+A one-member lexical enum is intentional. It gives lexical identity a stable
+category without mixing it with processes merely because only one lexical
+class is currently consumed.
+
+### 5. Recited writing is a derived view
+
+The core graph preserves source glyphs and domain relations. A recited-writing
+serializer may derive render glyphs from `write`, attributions, and insertion
+anchors. A slotless insertion is represented by its before/after anchor and
+its rendered sound; it is not forced into a fake unit or an empty source
+glyph.
+
+## Consequences
+
+The document is slightly more relational than a convenience DTO, but every
+legacy view becomes a pure adapter over one lossless source. Consumers that
+want convenience use derived indexes rather than receiving contradictory
+forward and reverse arrays.
+
+ADR-001 is amended only for the `SlotOrigin` decomposition and word-level
+lexical identity. ADR-002 and ADR-003 are reaffirmed at the public boundary:
+their typed edges are part of the contract, not internal detail.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,7 +36,7 @@ projection boundary that ADR-005 deferred.
 | [010](010-constants-that-restate-data.md) | A constant that restates a data file becomes the data, or a check against it |
 | [011](011-where-a-slot-is.md) | Adjacency on `Neighbourhood`, a required pass list, and a draft identity that survives being dropped |
 | [012](012-what-a-signature-may-leave-unsaid.md) | `del` for a parameter a protocol forces, checked rather than conventional |
-| [013](013-public-projection-foundations.md) | Public snapshots preserve typed spelling, attribution, and modifier edges |
+| [013](013-public-projection-foundations.md) | Public snapshots preserve typed domain edges and explicit glyph contribution |
 
 ## What this is for
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,8 +18,9 @@ the reasoning, because the principle generalises: a design rule catching a
 modelling error is the healthy direction, and weakening an invariant to fit the
 model is not.
 
-Read in order. 001–006 are the design; 007 is how it is laid out in code;
-008 is the gate the implementation must pass.
+Read in order. 001-006 are the design; 007 is how it is laid out in code;
+008 is the gate the implementation must pass. ADR-013 completes the public
+projection boundary that ADR-005 deferred.
 
 | ADR | Decision |
 |---|---|
@@ -35,6 +36,7 @@ Read in order. 001–006 are the design; 007 is how it is laid out in code;
 | [010](010-constants-that-restate-data.md) | A constant that restates a data file becomes the data, or a check against it |
 | [011](011-where-a-slot-is.md) | Adjacency on `Neighbourhood`, a required pass list, and a draft identity that survives being dropped |
 | [012](012-what-a-signature-may-leave-unsaid.md) | `del` for a parameter a protocol forces, checked rather than conventional |
+| [013](013-public-projection-foundations.md) | Public snapshots preserve typed spelling, attribution, and modifier edges |
 
 ## What this is for
 

--- a/docs/design/03-canonical-vocabulary.md
+++ b/docs/design/03-canonical-vocabulary.md
@@ -106,8 +106,9 @@ So the fact belongs on the slot. What is wrong is only the *reading* of
 - boundary-conditional: `SILAH` (long joined, absent at pause), `PAUSAL_LONG`
   (short joined, long at pause)
 
-No code change. `Reading` publishes `conditional: bool` so no consumer has to
-learn this (projections/01-design §3.2).
+No code change. `Reading` publishes the discriminated nucleus value and an SDK
+may derive `conditional: bool`, so no consumer has to infer it from sounds
+(projections/01-design section 3.2).
 
 ---
 
@@ -125,21 +126,21 @@ be both spelled and nunation *today*, but nothing in the domain says a spelled
 letter name may never end in tanween, and the enum makes that unsayable for no
 gain.
 
-**D2 -- `Annotation` is renamed `SlotTag`, and the sound-neutrality promise is
-dropped.** A `SlotTag` is a tag a slot carries, with no claim about sound.
-`DIVINE_NAME` keeps its membership; §3 shows the promise it violated bought
-nothing. The guarantee consumers actually need -- "phonemes are computed without
-reading tags" -- is delivered by the layering, since the phoneme sequence comes
-from `Performance` and `Performance` has no tag field.
+**D2 -- lexical identity and recitation processes split.** ADR-013 amends the
+earlier `SlotTag` proposal. `DIVINE_NAME` becomes a word-level `LexemeClass`;
+`IMALA` and `ISHMAM` are rule occurrences. A lexical fact is not put in the
+same enum as two recitation processes merely because all three arrived from
+annotations in the source corpus.
 
-Rejected: moving `DIVINE_NAME` out. It would need a `lexeme identity` field that
-exists for one member, which is a worse trade than an honest type name.
+The one-member lexical enum is deliberate. It names the stable category and
+can grow without another schema migration. The guarantee consumers need --
+"phonemes are computed from `Performance`" -- remains structural.
 
 **D3 -- `Onset` is not split.** The census found no possible manner-presence
 combination the enum cannot express, and every impossibility has a domain
 reason recorded in §4's table. Splitting buys nothing today and the projection
-publishes `geminate` and `prosthetic` as independent booleans regardless
-(projections/01-design §3.2), so no consumer inherits the coupling.
+can derive `geminate` and `prosthetic` as independent booleans
+(projections/01-design section 3.2), so no consumer inherits the coupling.
 
 This is a reversal of the acceptance criterion "every `Slot` field answers one
 question", and deliberately: the criterion is a heuristic for finding fields
@@ -150,9 +151,9 @@ Reopens if: a riwayah needs a geminate prosthetic hamza, or `TASHIL` grows a
 second member (Warsh's `naql` is a candidate, and it is a *deletion*, so it
 would sit on the presence axis with `WASL`).
 
-**D4 -- `PausalLong` and `Silah` stay.** §5. Documented as the
-boundary-conditional half of `NucleusKind`, with a docstring that says so, and
-the projection hides the distinction behind one boolean.
+**D4 -- `PausalLong` and `Silah` stay.** Section 5. They are documented as the
+boundary-conditional half of `NucleusKind`; the projection preserves the
+discriminated value and may derive a convenience boolean.
 
 ---
 
@@ -161,21 +162,21 @@ the projection hides the distinction behind one boolean.
 | | Change | Size |
 |---|---|---|
 | D1 | `SlotOrigin` -> `nunation` + `spelled`; 10 branches; digest; fixtures | medium |
-| D2 | `Annotation` -> `SlotTag`; rename only | small |
+| D2 | `DIVINE_NAME` -> word `LexemeClass`; imala and ishmam -> occurrences | medium |
 | D3 | none | -- |
 | D4 | `NucleusKind` docstring names the two axes | trivial |
 
 Two further changes are required by the projection design and are recorded
 there rather than here, because they are about `Performance`, not the canonical
-vocabulary: labelling `Participants` (projections/01-design §4, C1) and keeping
-the modifier edge (C2).
+vocabulary: labelling `Participants` (projections/01-design section 6, C1) and
+keeping the modifier edge (C2).
 
 ## 8. Acceptance, restated
 
 - No enum member means "none of the others". Met by D1; `PLAIN` in `Onset` is
   the articulated default, not an absence.
-- Any type documented as sound-neutral is sound-neutral. Met by D2, which
-  removes the false documentation rather than the true member.
+- Lexical identity is not represented as a recitation process. Met by D2.
 - Every field a *projection* exposes answers one question. Met by
-  projections/01-design §3.2, which is where the criterion belongs -- `Slot` is
-  internal and may carry a compressed enum if the compression is proven lossless.
+  projections/01-design section 3.2, which is where the criterion belongs --
+  `Slot` is internal and may carry a compressed enum if the compression is
+  proven lossless.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -30,8 +30,9 @@ wrong today rather than merely awkward.
 
 [projections/](projections/) is the public projection API that ADR-005 put out
 of scope: an audit of the four legacy projections and their consumers, a
-two-projection design over the layered model, and the equivalence gate that
-replacement has to pass. It assumes 03 resolved.
+two-projection design over the layered model, and the equivalence and
+completeness gate that replacement has to pass. ADR-013 settles its
+foundations and reconciles it with 03.
 
 ## Closed
 

--- a/docs/design/projections/00-audit.md
+++ b/docs/design/projections/00-audit.md
@@ -226,12 +226,12 @@ before either is public.
 
 ### 4.5 `write` totality is unproven for the cases that matter
 
-`orthography/write.py::write_verse` spells a `Score`. The projection's answer to
-"what glyph does an unwritten unit show?" is exactly this function. ADR-005 §4
-already names the trigger set: the 3:1 connected meem fatha, hamzat al-wasl
-helping vowels in all three flavours, madd iwad, taa marbuta at waqf, and every
-muqattaat expansion. Until that check passes, `Unit.glyphs` (01-design §3.2) has
-no guarantee.
+`orthography/write.py::write_verse` spells a `Score`. The recited-writing view
+uses it for canonical units and separately renders slotless insertions at their
+anchors. ADR-005 section 4 already names the trigger set: the 3:1 connected
+meem fatha, hamzat al-wasl helping vowels in all three flavours, madd iwad, taa
+marbuta at waqf, and every muqattaat expansion. Until that check passes, the
+derived recited-writing view has no totality guarantee.
 
 Two known asymmetries in `write` today, neither wrong but both visible in
 output: `NucleusKind.LONG` always spells haraka + carrier + madd sign rather
@@ -295,7 +295,7 @@ appear, is an empirical question the gate must answer (02-gate §3).
 | F3 | `Recolour`/`Relength` lose their occurrence at materialisation | `tafkheem` on a sound, `iltiqa` shortening |
 | F4 | `api.recitation` and `plan_from_request` exist; the ref-to-document loop above them does not | shipping anything |
 | F5 | Verse-scoped ids vs multi-verse consumers | wasl chains, ranged refs |
-| F6 | `write` totality unproven over ADR-005 §4's trigger set | `Unit.glyphs` |
+| F6 | `write` totality unproven over ADR-005 section 4's trigger set | recited writing |
 | F7 | Sound ownership for display is computed by the consumer | animation correctness |
 | F8 | `render/recite.py` occupies ADR-005's `recite` name | naming only |
 | F9 | `vowel_silent` residue unquantified | the equivalence gate |

--- a/docs/design/projections/01-design.md
+++ b/docs/design/projections/01-design.md
@@ -1,7 +1,7 @@
-# 01 - Two projections
+# 01 - Two projections over one lossless graph
 
-Status: **proposed**. Depends on [00-audit](00-audit.md) and on
-[03-canonical-vocabulary](../03-canonical-vocabulary.md) being resolved.
+Status: **proposed**. Depends on [00-audit](00-audit.md) and
+[ADR-013](../../adr/013-public-projection-foundations.md).
 Scope: Uthmani, Hafs.
 
 ## 1. The decision
@@ -10,319 +10,332 @@ Two public projections, and no third.
 
 | | Name | Shape | For |
 |---|---|---|---|
-| **P1** | `phonemes` | `tuple[str, ...]`, plus a per-word split | everyone who wants only sound |
-| **P2** | `Reading` | five parallel node arrays joined by integer index | everyone else |
+| **P1** | `phonemes` | ordered notation tokens, with word boundaries | consumers that want only sound |
+| **P2** | `Reading` | identified nodes plus typed relation arrays | every script, alignment, and tajweed consumer |
 
-`Reading` replaces `character_phoneme_mappings`, `letter_phoneme_mappings`,
-`silent_flags` and `tajweed_mappings` -- all four -- with no loss. It is one
-document because the four were one join computed four times (00-audit §1), and
-because a set of "atomic" projections over a graph is a set of tables a consumer
-must re-join, which is the thing that went wrong.
+`Reading` replaces `character_phoneme_mappings`,
+`letter_phoneme_mappings`, `silent_flags`, and `tajweed_mappings`. The four
+legacy APIs were four traversals of the same join, with different relationship
+losses. Publishing four smaller documents would require every consumer to
+reconstruct that join again.
 
-It does not couple, because the arrays are independently ignorable. A tajweed
-colourer for a mushaf reads `words`, `glyphs`, `units`, `rules` and never
-touches `phonemes`. An ASR labeller reads `phonemes` and `rules`. Ignoring an
-array costs nothing; re-joining two documents costs correctness.
+This does not force every consumer to load every relation. Named JSON fields
+are independently ignorable, and an SDK may provide lazy indexes or narrower
+views. The contract has one source of truth even when transport layers select
+only part of it.
 
-## 2. The key: a unit, not a character
+## 2. Identity and identifiers
 
-This is the load-bearing choice, and it is what the legacy projections got
-wrong.
-
-Legacy keyed rows on **written characters**, so anything recited but not written
-had no row. It grew `chars=""` implicit cells and a five-member `status` enum
-(`present`/`inserted`/`dropped`/`replaced`/`shortened`) to describe the gap, and
-downstream consumers still had to synthesize `madd_iwad`, `allah_dagger_alef`,
-`iltiqaa_kasra` and an iqlab mini-meem for themselves.
-
-`Reading` keys on the **`Slot`** -- published as `Unit`. A `Slot` is
-boundary-free and script-free: it exists whether or not this script wrote it and
-whether or not it sounds at this junction. Every legacy implicit cell is an
-ordinary unit:
-
-| Legacy implicit cell | Unit |
-|---|---|
-| hamza-wasl connecting vowel | a unit with `Onset.WASL` and a short nucleus |
-| iltiqa kasra (3:1) | an `Inserted` sound anchored to a unit |
-| Allah dagger alef | a unit with a `LONG` nucleus and the `divine_name` tag |
-| madd-iwad alef | a unit with a `PAUSAL_LONG` nucleus |
-| muqattaat name letters | units with `spelled = true` |
-
-Nothing is invented, and `status` disappears -- not because consumers stop
-wanting those five treatments, but because each is now *derived* from facts:
-
-```
-inserted  = unit.graphemes == () and unit.glyphs != ""
-dropped   = unit.graphemes != () and unit.sounds == ()
-replaced  = unit.glyphs differs from the text its graphemes spell
-shortened = a rule with `iltiqa_repair` names the unit
-present   = otherwise
-```
-
-The producer ships facts; the renderer keeps its vocabulary.
-
-## 3. `Reading`
-
-One request: a ref, a stop-sign policy (which advice classes are honoured), a
-riwayah, a `VariantSelection`. One document.
+A `Reading` is a snapshot of one fully identified request:
 
 ```python
 @dataclass(frozen=True)
 class Reading:
+    schema_version: str
+    request: ReadingRequest
+    score_digest: str
+
+    words: tuple[Word, ...]
+    glyphs: tuple[Glyph, ...]
+    units: tuple[Unit, ...]
+    sounds: tuple[SoundNode, ...]
+    occurrences: tuple[Occurrence, ...]
+
+    spellings: tuple[SpellingEdge, ...]
+    attributions: tuple[AttributionEdge, ...]
+    modifiers: tuple[ModifierEdge, ...]
+
+
+@dataclass(frozen=True)
+class ReadingRequest:
     ref: str
     riwayah: Riwayah
     script: Script
-    notation: str                      # the Alphabet that produced the tokens
-    selection: VariantSelection
-    words:    tuple[Word, ...]
-    glyphs:   tuple[Glyph, ...]
-    units:    tuple[Unit, ...]
-    phonemes: tuple[Phoneme, ...]
-    rules:    tuple[RuleHit, ...]
+    notation: str
+    selection: CanonicalVariantSelection
+    boundaries: BoundaryPlan
 ```
 
-Every cross-reference is an integer index into one of the five arrays, in both
-directions. Ids stay available as strings for stable external addressing.
+`selection` is serialized in canonical order. `boundaries` records starts,
+stops, sakt, and edges rather than only the stop-sign policy that produced
+them. `score_digest` identifies the canonical data against which indices were
+resolved.
+
+Every reference inside the document is an integer index into one array.
+Indices are local to this document. A bare slot label is not advertised as a
+durable external identifier: riwayah, selection, corpus revision, and schema
+edition all affect what it means. A future durable key must include that
+identity explicitly.
+
+The wire format stores each relationship once. Reverse indexes such as
+`units_by_word`, `glyphs_by_unit`, `sounds_by_unit`, and
+`occurrences_by_sound` are pure SDK helpers and are never serialized as
+parallel facts.
+
+## 3. Nodes
+
+Nodes carry intrinsic values and ordering. Relations live in section 4.
 
 ### 3.1 `Word`
 
 ```python
-location: Location          # 2:20:3
-text: str                   # the script's own word, verbatim
-spelled: str                # write() over this word's units
-starts: bool                # recitation began here
-stops: bool                 # recitation stopped after
-junction: Junction          # join | sakt | stop | edge
-advice: StopAdvice | None   # the mushaf's stop sign on this word
-units: tuple[int, ...]
-glyphs: tuple[int, ...]
+location: Location
+text: str
+starts: bool
+junction_after: Junction       # join | sakt | stop | edge
+advice: StopAdvice | None
+lexeme: LexemeClass | None     # currently divine_name
 ```
 
-`starts` / `stops` are the two facts every consumer re-derived from
-`is_starting` / `is_stopping`; `junction` is the full four-way fact underneath
-them. `advice` is new to a projection and comes free from `Inscription.advice`.
+`junction_after` is the complete boundary fact; `stops` would duplicate it.
+`starts` is independent because a range may begin inside a verse or word
+sequence. `lexeme` is lexical identity, not a tajweed tag. The occurrence that
+applies tafkheem to the relevant lam remains in the performance graph.
 
-### 3.2 `Unit` -- the spine
+Word membership points from a child node to its word. The corresponding word
+lists are derived indexes.
+
+### 3.2 `Unit`
 
 ```python
-id: str                     # "2:20#7"
 word: int
 letter: CanonLetter
-geminate: bool
-prosthetic: bool            # Onset.WASL: present only when started on
-conditional: bool           # this unit's presence or length depends on the junction
-nucleus: Quality | None     # None when silent
-length: NucleusKind         # silent | short | long | silah | pausal_long
-nunation: bool              # the tanween noon
-spelled: bool               # part of a muqattaat letter name
-tags: tuple[SlotTag, ...]   # ishmam | divine_name | imala
-graphemes: tuple[int, ...]  # what wrote it; () when unwritten
-glyphs: str                 # what it looks like -- always non-empty
-sounds: tuple[int, ...]     # what it produced here; () when silent
-silenced_by: int | None     # index into `rules`
-rules: tuple[int, ...]      # every rule naming this unit
+onset: Onset
+nucleus: Nucleus
+nunation: bool
+spelled: bool
 ```
 
-`glyphs` is the answer to "the keys of pure script orthography are the wrong
-choice". It is `write` applied to this one unit under this script's `Pen`, so it
-is always non-empty and always spellable in the script the consumer is
-rendering. When `graphemes` is empty, `glyphs` is the only thing to draw. When
-`graphemes` is non-empty and `glyphs` differs from the text they spell, the
-consumer has learned that the recited form and the written form diverge -- which
-is exactly the `replaced` case, stated as two facts instead of one enum member.
+`Nucleus` is the existing discriminated union:
 
-`conditional` collapses `Onset.SILAH`, `NucleusKind.SILAH` and
-`NucleusKind.PAUSAL_LONG` into the one thing a consumer must know: *do not read
-this unit's length as inherent; the junction decided it*. The precise kind is
-still in `length` for anyone who wants it.
+```python
+Silent | Short(quality) | Long(quality) | Silah(quality) | PausalLong(quality)
+```
+
+This forbids combinations such as `quality=None, length=long`. `Silah` and
+`PausalLong` remain lexical, boundary-conditional kinds; the performed sound
+still depends on the requested boundary plan.
+
+`Onset` remains one enum because the corpus and riwayah census found no valid
+combination it cannot express. SDKs may derive `geminate`, `prosthetic`, and
+`conditional` booleans for display. They are not additional wire facts.
+
+There are deliberately no glyph, sound, rule, silence-reason, or rendered-text
+fields on a unit. Those are relations or derived views. Madd counts and
+durations are also absent: they belong to realization or teaching policy, not
+to the canonical slot.
 
 ### 3.3 `Glyph`
 
 ```python
-id: str                     # "2:20@14"
-word: int
+word: int | None
 char: str
-cls: GraphemeClass          # base | haraka | tanween | shadda | length_carrier
-                            # | small_vowel | madd_sign | silence_sign
-                            # | annotation | advice | structural
-index: int                  # ordinal within the word
-units: tuple[int, ...]      # () for structural
-fact: SlotFact | None       # letter | onset | nucleus | sakt | annotation
-                            # None for Decorates / Attests
-attests: RuleFamily | None  # from Attests
+cls: GraphemeClass
+source_index: int
 ```
 
-`cls` is `GraphemeClass` unchanged and replaces legacy `role` exactly:
-`base`->`base`, `haraka`->`haraka`, `tanween`->`tanween`,
-`madd`->`length_carrier | small_vowel | madd_sign`. It is a fact about the mark,
-not a rendering slot, and it is finer than legacy's four.
+The index is the scalar's ordinal in the requested inscription. A structural
+glyph has `word=None`; it is not forced into a neighbouring word. A glyph does
+not flatten all its spelling edges into `units`, `fact`, and `attests`, because
+one glyph can participate in several differently typed edges.
 
-A compact grapheme reaching many units (the `الٓمٓ` opening: three graphemes,
-seven units) is `units` with length > 1. Legacy needed `source_letter_indices`
-plus a parallel `phoneme_rule_tags` array for the same thing.
-
-### 3.4 `Phoneme`
+### 3.4 `SoundNode`
 
 ```python
-id: int                     # == its index; the flat sequence position
 word: int
-token: str                  # the notation token
-kind: str                   # consonant | vowel | nasal | release
-letter: CanonLetter | None
-quality: Quality | None
-long: bool
-geminate: bool
-emphatic: bool
-nasal: bool
-units: tuple[int, ...]      # Hosts; () when Inserted
-owner: int | None           # THE unit that displays it
-merged_from: tuple[int, ...]# units whose own sound folded into this one
-anchor: tuple[int, str] | None   # (unit, "before" | "after") when Inserted
-rules: tuple[int, ...]      # every rule that produced, modified or classified it
+token: str
+spec: Consonant | Vowel | Nasal | Release
 ```
 
-Three fields earn their place:
+`token` is the selected notation's serialization of `spec`. The discriminated
+sound value already carries letter, quality, length, emphasis, gemination,
+nasality, place, or release kind where those concepts apply. A flat record
+with all of those fields optional would admit impossible sound states.
 
-- **`owner`.** Exactly one unit displays each sound. This is the fact
-  `ts-source.ts::lettersFromCells` reimplements ("the carrier wins over the
-  consonant's haraka") and gets to decide differently from the SDK. The rule is
-  stated once here and tested: for a nucleus-aspect sound the owner is the last
-  unit in `units`; for an onset-aspect sound, the first. `share_group`
-  disappears -- co-highlighting is "every unit in `units`", and a disjoint
-  animation is "the `owner` only".
-- **`merged_from`.** The disappearing side of an idgham. Legacy needed
-  `is_source` plus six rule-name tables to find it.
-- **`rules` is a list.** `secondary_tags` and `phoneme_rule_tags` were two
-  separate escape hatches for the fact that a sound carries more than one rule.
-  Both go.
+A sound has no stored unit, owner, merge source, insertion anchor, or rule
+list. Each is stated exactly by a relation in section 4.
 
-### 3.5 `RuleHit`
+### 3.5 `Occurrence`
 
 ```python
-id: int
 rule: Rule
-family: RuleFamily
-phase: Phase
-effect: str                 # hosts | insert | merge | silence | classify
-at: int                     # the anchor unit
-context: tuple[int, ...]    # the other participants
-units: tuple[int, ...]      # at + context
-phonemes: tuple[int, ...]   # every sound it produced, removed or coloured
+participants: tuple[Participant, ...]
+
+
+@dataclass(frozen=True)
+class Participant:
+    unit: int
+    role: ParticipantRole      # trigger | target | context
 ```
 
-`effect` replaces legacy's `source_rules` / `target_rules` partition, and is
-strictly more informative. On a cross-word idgham, legacy put the rule in
-`source_rules` on the disappearing noon and in `target_rules` on the receiving
-letter -- one bit, recovered from a hand-maintained table. Here the same rule is
-one `RuleHit` with `effect = merge`, `at` = the noon, `context` = the host, and
-`phonemes` = the single shared sound. Both sides fall out.
+Participants explain why a rule matched. Attribution and modifier edges
+explain what it did. This avoids a generic `effect` string that duplicates and
+weakens those relations.
 
-`effect = classify` is the fix for finding F1: madd, tafkheem, izhar and the
-other 15 classification-only rules get a hit with the sounds they name, so
-`Phoneme.rules` is complete rather than "whatever attributed the sound".
+`RuleFamily` and execution `Phase` are total functions of `Rule` in versioned
+registries. They are derived rather than repeated in every occurrence.
+`Rule.PLAIN` produces no occurrence; absence of a rule is plain.
 
-## 4. Model changes this requires
+## 4. Typed relations
 
-Three, all small, all in `model/` and `engine/`. Nothing in `rules/` changes
-behaviour.
+The public graph keeps the distinctions already settled in ADR-002 and
+ADR-003.
 
-**C1 -- label the participants** (fixes F2). `Participants` becomes
+### 4.1 Spelling
 
 ```python
-@dataclass(frozen=True, slots=True)
-class Participants:
-    at: SlotId
-    context: tuple[SlotId, ...] = ()
+Evidences(glyph: int, unit: int, fact: SlotFact)
+Attests(glyph: int, family: RuleFamily, anchor: int)
+Decorates(glyph: int, unit: int)
+Structural(glyph: int)
+
+SpellingEdge = Evidences | Attests | Decorates | Structural
 ```
 
-21 call sites, mechanical. `rules/madd.py:69` is the one that changes meaning:
-its `(before.id, at)` becomes `at=at, context=(before.id,)`, matching every
-other rule. Without this the `at` / `context` split in `RuleHit` is a guess.
+This preserves many-to-many script evidence without conflating its meaning.
+The long-vowel haraka and carrier may both reach one unit through distinct
+edges. A compact muqattaat grapheme may evidence facts on several units.
+`Attests` witnesses a performance family without asserting a canonical fact.
+`Structural` has no unit and no word.
 
-**C2 -- keep the modifier edge** (fixes F3). `engine/run.py` consumes `Recolour`
-and `Relength` and discards which occurrence emitted them. Record them:
+### 4.2 Attribution
 
 ```python
-@dataclass(frozen=True, slots=True)
-class Modifies:
-    sound: SoundId
-    by: OccurrenceId
+Hosts(units: tuple[int, ...], aspect: Aspect, sound: int, by: int)
+Inserted(anchor: tuple[int, Side], aspect: Aspect, sound: int, by: int)
+MergedInto(units: tuple[int, ...], aspect: Aspect, sound: int, by: int)
+Silent(units: tuple[int, ...], aspect: Aspect, by: int)
+
+AttributionEdge = Hosts | Inserted | MergedInto | Silent
 ```
 
-added to the `Attribution` union or carried as a separate
-`Performance.modifiers` tuple. Separate tuple is preferred: `Modifies` does not
-own a sound, and the P1 law ("every sound is hosted exactly once") should not
-have to special-case it.
+`Aspect` is mandatory. A final consonant can host an onset sound while a
+separate nucleus attribution is silent at pause. That fact cannot be recovered
+from sound kind.
 
-**C3 -- the ref-to-document loop** (fixes F4). Not a design question, but it is
-the gate on shipping. `api.recitation(riwayah)` already assembles a riwayah and
-`engine/boundary_plan.py::plan_from_request(advice, stop_at, score=)` already
-turns a stop policy into a `BoundaryPlan`. What is missing sits above both: take
-`(ref, stop policy, selection)`, resolve the ref through
-`PackedCorpus.locations`, run `read` -> `build` -> `perform` per verse, and
-assemble one `Reading` across them.
+`Inserted` preserves both the anchor and before/after side, so the 3:1 iltiqa
+vowel needs neither a fake unit nor an empty glyph. A merger is a `Hosts` edge
+and a `MergedInto` edge sharing sound and occurrence. Joint hosting remains a
+tuple of units; it is not reduced to one preferred owner.
 
-Deliberately **not** changed:
+### 4.3 Modification
 
-- `CLASSIFICATION_ONLY` stays. It is the correct statement that a rule owns no
-  sound; C2 gives it an edge without giving it ownership.
-- `SlotOrigin` decomposition, `Annotation` naming: see
-  [03](../03-canonical-vocabulary.md), which this design assumes resolved.
-- `Onset` splitting: not required. `Reading` publishes `geminate` and
-  `prosthetic` as separate booleans regardless of the internal enum shape,
-  which is the whole point of a projection.
+```python
+Recolours(sound: int, by: int, feature: SoundFeature, value: bool)
+Relengths(sound: int, by: int, length: Length)
+Classifies(sound: int, by: int)
 
-## 5. Rule vocabulary
+ModifierEdge = Recolours | Relengths | Classifies
+```
 
-**Keep the branch `Rule` set unchanged.** Three properties make it better than
-legacy's and all three should survive:
+These edges retain the occurrence after the engine applies an effect.
+`Classifies` connects a classification-only occurrence to a sound without
+claiming ownership. A soundless gesture such as ishmam is still represented by
+its occurrence and target participant; it does not receive a fake sound.
 
-1. **Trigger-independent naming.** One `IKHFAA_HAQIQI`, not `ikhfaa_noon` +
-   `ikhfaa_tanween`. The trigger is `unit.nunation`, which the consumer has. A
-   rule name that encodes its own trigger multiplies with every new trigger.
-2. **`FAMILY_OF` is total.** Every rule declares a `RuleFamily`, so a consumer
-   that does not want 40 colours gets 7 for free and a new rule lands in an
-   existing bucket instead of falling off the legend.
-3. **Degrees are separate members.** `QALQALA_SUGHRA` / `KUBRA` / `AKBAR`,
-   `IDGHAM_MUTAJANISAYN_KAMIL` / `NAQIS`. A projection that cannot say which
-   degree fired is not a tajweed projection.
+## 5. Derived views, not stored facts
 
-One rename to consider and one to reject:
+The following conveniences have named definitions:
 
-- `Rule.PLAIN` is the plain-fill sentinel, not a tajweed rule. In `RuleHit` it
-  should either be omitted (a sound with no `rules` entry is plain) or kept with
-  `family = ELISION`, which is wrong. **Omit it.** A `Phoneme` with empty `rules`
-  is plain; that is one less vocabulary item a consumer must learn to ignore.
-- Do **not** split `TAFKHEEM` by cause (istilaa vs raa vs divine name). The
-  cause is recoverable from `at.letter` and `at.tags`, and splitting re-imports
-  legacy's trigger-in-the-name mistake.
+```text
+units_by_word(w)       = units whose word is w
+glyphs_by_unit(u)      = spelling edges naming u
+sounds_by_unit(u, a)   = attribution edges naming u and aspect a
+rules_by_sound(s)      = occurrences reached by attribution or modifier edges
+family(o)              = FAMILY_OF[occurrences[o].rule]
+phase(o)               = PHASE_OF[occurrences[o].rule]
+```
 
-## 6. What each application gets
+Display ownership is also derived, but it is explicitly a rendering policy,
+not domain ownership:
 
-| Application | Reads | Was |
-|---|---|---|
-| Inspector cells | `glyphs`, `units`, `phonemes`, `rules` | `character_phoneme_mappings` + 2 FE surgeries + 7 synthesized tags |
-| Silent co-highlight | `unit.sounds == ()`; the mark is the neighbouring `silence_sign` glyph | `silent_flags` |
-| Aligner letter timing | `phoneme.owner` for disjoint spans, `phoneme.units` for co-light | `lettersFromCells` heuristic |
-| Cross-word bridge | a `RuleHit` with `effect = merge` and units in two words | `detect_cross_word_mergers` + 2 re-exported rule sets |
-| Flat char-to-phoneme runs | `units` with `graphemes` and `sounds` | `letter_phoneme_mappings` |
-| Tajweed-coloured mushaf | `glyphs` -> `units` -> `rules` | `tajweed_mappings` |
-| Tajweed ASR / error detection | `phonemes` + `phoneme.rules` + `selection`, with `khilaf().points()` for the alternatives | not possible |
-| Custom notation | swap the `Alphabet`; `token` changes, nothing else does | not possible |
+```text
+display_glyph(sound, policy)
+  = choose among glyphs that evidence the attributed unit and aspect
+```
 
-## 7. Open questions
+This can choose a haraka or a length carrier. A stored `owner: Unit` cannot,
+because both glyphs may evidence the same unit.
 
-1. **Multi-verse documents.** Finding F5. Ids are already `VerseRef`-qualified,
-   so a `Reading` over a range is concatenation plus a decision about whether
-   array indices restart. Proposal: they do not -- one `Reading`, one index
-   space, `word.location` carries the verse.
-2. **`Unit.glyphs` guarantee.** Blocked on ADR-005 §4's totality gate (F6). If
-   `write` cannot spell a recited form, `glyphs` needs a nullable escape and the
-   ADR-005 refusal of a fourth layer has failed its own trigger.
-3. **Serialization.** Legacy shipped positional tuples and grew four
-   append-only slots. `Reading` should ship named JSON; the positional shard row
-   is the *consumer's* encoding, not the producer's, and the SDK already
-   projects into a different field order. This wants stating so it does not
-   recur.
-4. **Does the Uthmani inventory read `ۢ`?** Finding F10. If not, `Glyph.units`
-   will not attach the iqlab small meem and the frontend surgery survives.
+Recited writing is a separate serializer over `write`, spelling, attribution,
+and insertion anchors. It may return render glyphs with source-glyph links.
+For a slotless insertion it writes the inserted sound at its anchor side.
+Source glyphs remain unchanged, and no core `Unit.glyphs` field is promised
+non-empty.
+
+Legacy presentation states become pure derivations:
+
+```text
+inserted  = an Inserted attribution
+dropped   = a Silent attribution for the relevant aspect
+merged    = paired Hosts and MergedInto attributions
+replaced  = rendered writing differs from source spelling
+shortened = a Relengths edge to short
+present   = none of the above
+```
+
+## 6. Model work required
+
+The projection exposes three gaps that must be fixed before it ships.
+
+**C1 - semantic participant roles.** Replace the unlabelled
+`Participants.slots` tuple with ordered `Participant(unit, role)` values. This
+is not a mechanical first/other split: each rule family must state trigger,
+target, and context from its domain grammar. Tests assert the roles for
+cross-word assimilation, madd, boundary elision, and classification-only
+rules.
+
+**C2 - retained modifier provenance.** When the engine applies `Recolour` or
+`Relength`, retain the occurrence-to-sound edge and its value. Add
+`Classifies` for a classification-only occurrence that names a sound. This
+closes the current loss between verdict application and `Performance`.
+
+**C3 - ref-to-document orchestration.** Resolve `(ref, boundary policy,
+selection)` through the selected corpus, build the Score and Inscription, run
+the Performance, and assemble one index space across the requested range.
+Internal starts, arbitrary stops, sakt, and cross-verse joins use the same
+path; they are not separate projection modes.
+
+No rule behaviour changes as part of C1-C3. `CLASSIFICATION_ONLY` remains a
+valid statement that an occurrence owns no sound.
+
+## 7. Rule vocabulary
+
+Keep the branch `Rule` set:
+
+1. Names are trigger-independent. Noon and tanween ikhfa share one rule; the
+   trigger is a participant and `unit.nunation`.
+2. `FAMILY_OF` is total, so a coarse legend is derived without serializing a
+   second classification beside every occurrence.
+3. Degrees remain distinct rules, such as the qalqala and idgham degrees.
+
+Omit `Rule.PLAIN` from occurrences. Do not split `TAFKHEEM` by cause: the
+occurrence participants and lexical identity state why it applied.
+
+## 8. What consumers read
+
+| Application | Reads |
+|---|---|
+| Inspector cells | nodes plus spelling, attribution, and modifier indexes |
+| Silent highlighting | `Silent` attributions and related spelling edges |
+| Disjoint timing | a chosen `display_glyph` policy |
+| Co-highlighting | all units on the relevant `Hosts` edge |
+| Cross-word bridge | paired `Hosts` and `MergedInto` edges |
+| Flat letter mappings | a legacy adapter over spelling and attribution |
+| Tajweed-coloured script | spelling edges to occurrence participants and modifiers |
+| Tajweed ASR | sounds, occurrences, modifiers, and request selection |
+| Custom notation | the same graph with a different `token` serializer |
+
+## 9. Shipping questions
+
+The graph shape is settled by ADR-013. Three empirical questions remain gate
+items rather than schema choices:
+
+1. Does the Uthmani inventory bind every iqlab small meem through a typed
+   spelling edge?
+2. Is recited writing total for every unit and slotless insertion in the
+   corpus?
+3. Does every preserved legacy field round-trip exactly in continuous, verse,
+   and word boundary modes?
+
+[02-equivalence-gate](02-equivalence-gate.md) makes each one executable.

--- a/docs/design/projections/01-design.md
+++ b/docs/design/projections/01-design.md
@@ -44,6 +44,7 @@ class Reading:
     spellings: tuple[SpellingEdge, ...]
     attributions: tuple[AttributionEdge, ...]
     modifiers: tuple[ModifierEdge, ...]
+    contributions: tuple[GlyphContributionEdge, ...]
 
 
 @dataclass(frozen=True)
@@ -164,13 +165,26 @@ participants: tuple[Participant, ...]
 
 @dataclass(frozen=True)
 class Participant:
+    anchor: AspectRef
+    role: ParticipantRole      # trigger | source | target | context
+
+
+@dataclass(frozen=True)
+class AspectRef:
     unit: int
-    role: ParticipantRole      # trigger | target | context
+    aspect: Aspect
 ```
 
 Participants explain why a rule matched. Attribution and modifier edges
 explain what it did. This avoids a generic `effect` string that duplicates and
 weakens those relations.
+
+Roles are closed and checked against the rule family's participant schema.
+`trigger` is the condition that made the rule applicable; `source` is its
+canonical locus; `target` is the affected anchor; and `context` records a
+required participant with none of those meanings. `host`, `contributor`, and
+`carrier` are not repeated here: attribution edges state host and contributor,
+while spelling and contribution edges state carrier participation.
 
 `RuleFamily` and execution `Phase` are total functions of `Rule` in versioned
 registries. They are derived rather than repeated in every occurrence.
@@ -233,6 +247,27 @@ These edges retain the occurrence after the engine applies an effect.
 claiming ownership. A soundless gesture such as ishmam is still represented by
 its occurrence and target participant; it does not receive a fake sound.
 
+### 4.4 Glyph contribution
+
+```python
+Presents(glyph: int, target: PerformanceRef)
+OrthographicOnly(glyph: int)
+
+PerformanceRef = AttributionRef | ModifierRef | OccurrenceRef
+GlyphContributionEdge = Presents | OrthographicOnly
+```
+
+Each reference variant is a tagged index into the named relation or occurrence
+array. A glyph may have several `Presents` edges. `OrthographicOnly` is
+exclusive and means the glyph has no performance contribution; its spelling
+edge still states its canonical or structural attachment.
+
+This relation cannot be inferred from unit audibility. A haraka and carrier
+can evidence the same nucleus and share its vowel, while a carrier waw under a
+dagger is orthographic-only and the dagger presents the vowel. A maddah can
+present an attribution or modifier despite supplying no canonical fact. A
+soundless ishmam mark can present its occurrence without fabricating a sound.
+
 ## 5. Derived views, not stored facts
 
 The following conveniences have named definitions:
@@ -242,6 +277,7 @@ units_by_word(w)       = units whose word is w
 glyphs_by_unit(u)      = spelling edges naming u
 sounds_by_unit(u, a)   = attribution edges naming u and aspect a
 rules_by_sound(s)      = occurrences reached by attribution or modifier edges
+performance_by_glyph(g)= targets of Presents edges for g
 family(o)              = FAMILY_OF[occurrences[o].rule]
 phase(o)               = PHASE_OF[occurrences[o].rule]
 ```
@@ -251,23 +287,23 @@ not domain ownership:
 
 ```text
 display_glyph(sound, policy)
-  = choose among glyphs that evidence the attributed unit and aspect
+  = choose among glyphs whose Presents targets reach sound
 ```
 
 This can choose a haraka or a length carrier. A stored `owner: Unit` cannot,
 because both glyphs may evidence the same unit.
 
-Recited writing is a separate serializer over `write`, spelling, attribution,
-and insertion anchors. It may return render glyphs with source-glyph links.
-For a slotless insertion it writes the inserted sound at its anchor side.
-Source glyphs remain unchanged, and no core `Unit.glyphs` field is promised
-non-empty.
+Recited writing is a separate serializer over `write`, spelling, contribution,
+attribution, and insertion anchors. It may return render glyphs with
+source-glyph links. For a slotless insertion it writes the inserted sound at
+its anchor side. Source glyphs remain unchanged, and no core `Unit.glyphs`
+field is promised non-empty.
 
 Legacy presentation states become pure derivations:
 
 ```text
 inserted  = an Inserted attribution
-dropped   = a Silent attribution for the relevant aspect
+dropped   = a source glyph Presents a Silent attribution, or is OrthographicOnly
 merged    = paired Hosts and MergedInto attributions
 replaced  = rendered writing differs from source spelling
 shortened = a Relengths edge to short
@@ -276,27 +312,35 @@ present   = none of the above
 
 ## 6. Model work required
 
-The projection exposes three gaps that must be fixed before it ships.
+The projection exposes four gaps that must be fixed before it ships.
 
 **C1 - semantic participant roles.** Replace the unlabelled
-`Participants.slots` tuple with ordered `Participant(unit, role)` values. This
-is not a mechanical first/other split: each rule family must state trigger,
-target, and context from its domain grammar. Tests assert the roles for
-cross-word assimilation, madd, boundary elision, and classification-only
-rules.
+`Participants.slots` tuple with ordered `Participant(AspectRef, role)` values.
+This is not a mechanical first/other split: each rule family must define its
+allowed and required trigger, source, target, and context roles. Tests assert
+the roles for cross-word assimilation, madd, boundary elision, and
+classification-only rules.
 
 **C2 - retained modifier provenance.** When the engine applies `Recolour` or
 `Relength`, retain the occurrence-to-sound edge and its value. Add
 `Classifies` for a classification-only occurrence that names a sound. This
 closes the current loss between verdict application and `Performance`.
 
-**C3 - ref-to-document orchestration.** Resolve `(ref, boundary policy,
+**C3 - total glyph contribution.** Build the cross-layer join that tells which
+performance targets each glyph presents. Every non-structural glyph has one or
+more `Presents` edges or exactly one `OrthographicOnly` edge. The construction
+must distinguish a sounded dagger from its silent carrier, a sounded maddah
+from an otiose seat, and a performance deletion from orthographic zero. If
+the source model cannot determine a link, it must be fixed below the
+projection; serializers may not detect the answer from tokens or rule names.
+
+**C4 - ref-to-document orchestration.** Resolve `(ref, boundary policy,
 selection)` through the selected corpus, build the Score and Inscription, run
 the Performance, and assemble one index space across the requested range.
 Internal starts, arbitrary stops, sakt, and cross-verse joins use the same
 path; they are not separate projection modes.
 
-No rule behaviour changes as part of C1-C3. `CLASSIFICATION_ONLY` remains a
+No rule behaviour changes as part of C1-C4. `CLASSIFICATION_ONLY` remains a
 valid statement that an occurrence owns no sound.
 
 ## 7. Rule vocabulary
@@ -316,20 +360,20 @@ occurrence participants and lexical identity state why it applied.
 
 | Application | Reads |
 |---|---|
-| Inspector cells | nodes plus spelling, attribution, and modifier indexes |
-| Silent highlighting | `Silent` attributions and related spelling edges |
+| Inspector cells | nodes plus spelling, contribution, attribution, and modifier indexes |
+| Silent highlighting | `Presents(Silent)` and `OrthographicOnly` contribution edges |
 | Disjoint timing | a chosen `display_glyph` policy |
 | Co-highlighting | all units on the relevant `Hosts` edge |
 | Cross-word bridge | paired `Hosts` and `MergedInto` edges |
 | Flat letter mappings | a legacy adapter over spelling and attribution |
-| Tajweed-coloured script | spelling edges to occurrence participants and modifiers |
+| Tajweed-coloured script | contribution edges to occurrences, attributions, and modifiers |
 | Tajweed ASR | sounds, occurrences, modifiers, and request selection |
 | Custom notation | the same graph with a different `token` serializer |
 
 ## 9. Shipping questions
 
-The graph shape is settled by ADR-013. Three empirical questions remain gate
-items rather than schema choices:
+The current graph shape is settled by ADR-013. Three empirical gate items and
+one scoped extension question remain:
 
 1. Does the Uthmani inventory bind every iqlab small meem through a typed
    spelling edge?
@@ -337,5 +381,8 @@ items rather than schema choices:
    corpus?
 3. Does every preserved legacy field round-trip exactly in continuous, verse,
    and word boundary modes?
+4. What transmission path or realization policy would make permitted and
+   selected madd counts authoritative? Until the request can identify it,
+   counts remain outside the contract.
 
 [02-equivalence-gate](02-equivalence-gate.md) makes each one executable.

--- a/docs/design/projections/02-equivalence-gate.md
+++ b/docs/design/projections/02-equivalence-gate.md
@@ -1,170 +1,301 @@
-# 02 - The equivalence gate
+# 02 - The equivalence and completeness gate
 
-Status: **proposed**. The acceptance criterion for [01-design](01-design.md).
+Status: **proposed**. This is the acceptance criterion for
+[01-design](01-design.md).
 
-## 1. The rule
+## 1. What the gate proves
 
-Every fact the legacy projections published must either
+Replacement needs two independent proofs:
 
-- have a **1-1 mapping** into `Reading` proving equivalence, or
-- have an **adapter** proving equivalence, where the adapter is a pure function
-  of `Reading` alone (a rule rename, a trigger split, an edge-kind read).
+1. **Legacy preservation.** Every legacy field promised during migration is
+   reproduced exactly by a pure adapter over `Reading`.
+2. **Graph completeness.** Every new typed relation is complete and obeys its
+   domain laws, including facts for which legacy has no oracle.
 
-Two exemptions, both stated up front:
+Passing only the first would preserve legacy loss. Passing only the second
+would permit accidental consumer regressions.
 
-- **Phoneme corrections from PR #39.** Where the branch deliberately produces a
-  different sound than `main`, the difference is a fix and is out of scope. The
-  gate compares *structure and labels*, not tokens, wherever a token changed;
-  the token diff is already covered by `out/phonemized_v*` regression.
-- **Additive facts.** Rules, relationships and fields that `Reading` exposes and
-  legacy did not (`IZHAR_*`, `IWAD`, `advice`, `owner`, `merged_from`,
-  `effect`, `phase`, `attests`) are not gated. Nothing has to consume them.
+The frozen legacy data is an information-coverage reference, not a correctness
+oracle. A mismatch has exactly one of these dispositions:
 
-Anything else is a regression.
+- `regression`: unexplained, and the gate fails;
+- `correction`: one exact old/new case in a reviewed corrections ledger, with
+  its domain reason and regression test;
+- `addition`: excluded from the legacy adapter but required by a new-graph law;
+- `retirement`: an explicitly named legacy presentation promise, approved
+  before the gate runs.
 
-## 2. Mechanism
+There is no broad exemption for changed tokens or additive fields. A token
+correction is allowlisted at the affected refs and boundary modes. A new edge
+must pass completeness laws even though the legacy side cannot contain it.
 
-`tools/projection_parity.py`. For every verse of the corpus, at each of the
-three waqf levels the manual regression corpus already uses
-(`out/phonemized_v*`: `v`, `vqm`, `vqsjm`):
+## 2. Frozen reference and execution matrix
 
-1. Build the legacy projections from `main` (a pinned checkout or an installed
-   pre-refactor wheel).
-2. Build `Reading` from the branch at the same ref and boundary policy.
-3. Run the adapters below.
-4. Assert field-by-field equality; write every mismatch to a residue report
-   grouped by cause, not by verse.
+`research/legacy-baselines/manifest.json` is the source of truth. It pins
+legacy revision `b3bc53a`, reference `1-114`, native row shapes, byte counts,
+and SHA-256 digests for:
 
-The report is the deliverable, not a pass/fail. A gate that says "1,412
-mismatches" is useless; one that says "1,398 of them are `vowel_silent` on a
-taa marbuta at waqf" closes an item.
+- phonemes;
+- tajweed mappings;
+- letter-to-phoneme mappings;
+- character-to-phoneme mappings;
+- silent flags;
+- phonetic text.
 
-## 3. Adapters, one per legacy projection
+The harness verifies every manifest digest before comparison. It does not
+silently regenerate the reference from the current checkout.
 
-### 3.1 `silent_flags()` -> `[(char, silent, mark)]`
+The full-corpus baseline runs in all three committed modes:
 
-The tightest of the four and the right one to do first: it is one tuple per
-written grapheme in reading order, and `qua_shared` has proven it 1-1 against a
-real shard.
+| Mode | Boundary meaning |
+|---|---|
+| `continuous` | no requested stops |
+| `verse` | stop at verse boundaries |
+| `word` | stop after every source word |
 
+Those modes cover the bulk corpus but not request orchestration. A separate
+fixture matrix covers:
+
+- a range beginning inside a verse;
+- an arbitrary internal stop;
+- sakt;
+- a cross-word and cross-verse join;
+- a multi-verse range in one index space;
+- every non-default `VariantSelection` point;
+- each stop-advice policy that changes the resulting `BoundaryPlan`.
+
+Where the pinned legacy API can express the request, the fixture compares both
+implementations. Otherwise it asserts the domain result and graph laws
+directly. The report says which kind of oracle each fixture used.
+
+## 3. Exact legacy adapters
+
+`tools/projection_parity.py` is the planned harness. For each manifest mode it:
+
+1. loads `Reading` for the same source request;
+2. applies one pure adapter per legacy view;
+3. compares native rows, field order where positional, values, and row order;
+4. reports residues by adapter, field, rule, boundary mode, and cause;
+5. exits non-zero for any residue without an approved disposition.
+
+Counts and merge-direction agreement are diagnostics, not equivalence. The
+acceptance test is exact equality after the documented adapter.
+
+### 3.1 Preserved and intentionally changed promises
+
+| Legacy view | Migration promise |
+|---|---|
+| `phonemes` | exact tokens and word grouping, except exact correction-ledger entries |
+| `phonetic_text` | exact lines and order, except the same correction entries |
+| `silent_flags` | exact tuple rows after legacy tokenization |
+| `tajweed_mappings` | exact legacy rule vocabulary and source/target rows after the vocabulary adapter |
+| `letter_phoneme_mappings` | exact characters, tokens, grouping, row order, and merge direction |
+| `character_phoneme_mappings` | exact cells and every legacy field after the presentation adapter |
+
+No current field is declared retired. If exact letter grouping or a cell field
+cannot be reconstructed, the design is incomplete until the field is either
+made derivable or explicitly retired with consumer approval.
+
+New rule families and richer edges do not appear as surprise extra rows in a
+legacy adapter. The adapter selects the legacy vocabulary; the completeness
+suite separately proves the new facts exist.
+
+### 3.2 `silent_flags`
+
+For each non-structural source token:
+
+```text
+units  = units reached by its Evidences and Decorates edges
+silent = every relevant attributed aspect has a Silent outcome
+mark   = the adjacent silence-sign glyph bound to the same unit, or ""
 ```
-for glyph in reading.glyphs where glyph.cls != structural:
-    char   = glyph.char
-    silent = all(reading.units[u].sounds == () for u in glyph.units)
-    mark   = the char of an adjacent silence_sign glyph on the same units, or ""
-```
 
-Three known divergences to confirm rather than assume:
+The adapter then applies the legacy scalar grouping exactly: dagger alif,
+mini-waw, and mini-yaa remain separate where legacy separated them; other
+combining marks rejoin their base. The following named cases must be exact:
 
-- **Tokenization.** Legacy splits only the dagger alef, mini-waw and mini-yaa
-  into their own entries; every other combining mark merges onto the grapheme
-  before it. `Reading.glyphs` is one entry per grapheme. The adapter must
-  re-merge, and the merge rule must be shown to be the same one.
-- **Carrier waw** (`صَلَوٰة`, `زَكَوٰة`). Legacy special-cases a waw that is a silent
-  seat for a dagger-alef madd. In `Reading` this should fall out of
-  `glyph.units` and `unit.sounds` with no special case. If it does not, that is
-  a modelling finding, not an adapter one.
-- **Silah at waqf.** Legacy marks the mini-waw/yaa silent when the word stops.
-  In `Reading` the unit has `conditional = true` and `sounds = ()`. Should be
-  exact.
+- a silent carrier waw under dagger alif;
+- mini-waw and mini-yaa silah at pause;
+- taa marbuta at pause;
+- all legacy `vowel_silent` rows.
 
-### 3.2 `tajweed_mappings()` -> `{char, source_rules[], target_rules[]}`
+Every silent outcome must name an occurrence. The residue report groups
+`vowel_silent` by the actual rule and fails if any row has no reason.
 
-```
-for each legacy entry, find its glyph; for each unit of that glyph:
-    for each RuleHit naming the unit:
-        source_rules  += rule if hit.at is this unit
-        target_rules  += rule if this unit is in hit.context
-    then apply the vocabulary adapter (00-audit §5)
-```
+### 3.3 `tajweed_mappings`
 
-The `is_source` bit maps onto `at` vs `context`, which is why C1 (labelling
-`Participants`) is a prerequisite and not a nicety. Expected residue, all of
-which should be *extra* rules on the new side:
+Occurrence participants supply trigger, target, and context; spelling edges
+locate the source glyphs; attribution and modifier edges locate the affected
+sound. A versioned vocabulary table maps the current `Rule` to the legacy
+rule names and trigger splits.
 
-- `IZHAR_*` and `LAM_QAMARIYYAH` on letters legacy left bare.
-- `TAFKHEEM` reaching sounds legacy reached only through
-  `HEAVY_VOWEL_PHONEMES = {"aˤ:"}`, a phoneme-shape test.
-- Madd rules on units where legacy's `MADD_TYPE_MAP` collapsed `iwad` into
-  `MADD_TABII`.
+Source and target are reconstructed from semantic roles, not tuple position.
+For assimilation, the disappearing trigger and receiving target are distinct
+even though both relate to one sound. New rules such as explicit izhar are
+filtered from the compatibility view and checked by graph completeness.
 
-### 3.3 `letter_phoneme_mappings()` -> `[(chars, phonemes)]`
+The adapter must reproduce every legacy word split, character string,
+`source_rules`, `target_rules`, and row order exactly.
 
-The loosest, because legacy's entry boundaries are the *output* of five merge
-tables. Reconstruct them from `Reading`:
+### 3.4 `letter_phoneme_mappings`
 
-```
-start from units in order; a unit with sounds == () merges into
-  - the next unit, when its silencing rule is one of
-    {wasl_elision, lam_shamsiyyah, iltiqa_repair}
-  - the unit hosting the sound it merged into, when the edge is a merge
-  - otherwise the previous unit
-chars    = concatenation of the merged units' glyphs
-phonemes = the merged units' sounds, in order
-```
+This adapter intentionally owns the legacy presentation grouping. It starts
+from source glyph order, typed spelling edges, and aspect-bearing
+attributions, then applies the versioned legacy merge policy.
 
-The gate here is not row-for-row identity -- it is that the *derived* merge
-direction agrees with legacy's table lookup on every letter. Where it does not,
-one of the two is wrong about the domain and the disagreement is the finding.
+The test is row-for-row equality, including:
 
-Two known re-attributions legacy performs after the fact and `Reading` does not
-need, because the unit already holds the answer: iltiqa demotion of a shortened
-long vowel onto the preceding consonant, and waqf-tanween redistribution of the
-long vowel onto the otiose alif. Both must be shown to land on the same glyph.
+- silent units merged left or right;
+- lam-shamsiyyah and wasl elision;
+- idgham source and host grouping;
+- iltiqa shortening;
+- waqf tanween and the otiose alif;
+- muqattaat expansions.
 
-### 3.4 `character_phoneme_mappings()` -> cells
+Agreement only on merge direction is insufficient. The public claim is that
+the old view is derivable, so its exact grouping must be derivable.
 
-The largest, and the one where "1-1" is the wrong ambition -- the cell schema
-carries presentation state that `Reading` deliberately does not. Per field:
+### 3.5 `character_phoneme_mappings`
 
-| Cell field | From `Reading` | Kind |
-|---|---|---|
-| `chars` | `unit.glyphs`, or the glyph's `char` | 1-1 |
-| `role` | `glyph.cls`, folded 11 -> 4 | 1-1, lossy in the safe direction |
-| `status` | derived, 01-design §2 | adapter |
-| `phonemes` | `unit.sounds` -> `phoneme.token` | 1-1 |
-| `phoneme_indices` | `unit.sounds`, rebased word-local | 1-1 |
-| `tag` | the highest-priority `RuleHit` on the unit | adapter, keeps legacy's priority order |
-| `secondary_tags` | the rest of them | adapter |
-| `phoneme_rule_tags` | `phoneme.rules` per sound | 1-1 |
-| `share_group` | units sharing a `phoneme.id` | adapter |
-| `source_letter_index` | `glyph.index` | 1-1 |
-| `source_letter_indices` | `glyph.units` -> their glyphs | 1-1 |
+Every legacy field is adapted:
 
-The cases to check by name, because each is one of the seven synthesized tags or
-two surgeries from 00-audit §2.1: the hamza-wasl helping vowel (all three
-qualities), the 3:1 iltiqa fatha, the Allah dagger alef, the madd-iwad alif at
-waqf, the dropped silah at waqf, taa marbuta at waqf, the iqlab noon and its
-small meem, and every muqattaat opening.
+| Cell field | Source in `Reading` |
+|---|---|
+| `chars` | source spelling or derived recited writing |
+| `role` | folded `GraphemeClass` |
+| `status` | typed attribution plus source/rendered difference |
+| `phonemes` | attributed sound tokens |
+| `phoneme_indices` | sound indices rebased word-local |
+| `tag` | legacy priority over compatible occurrences |
+| `secondary_tags` | remaining compatible occurrences |
+| `phoneme_rule_tags` | occurrences reached by attribution and modifier edges |
+| `share_group` | units on joint or shared sound relations |
+| `source_letter_index` | source glyph index |
+| `source_letter_indices` | spelling edges back to source glyphs |
 
-## 4. Residue that closes a finding
+The priority order and four-role fold are compatibility policy in this adapter,
+not facts copied into the core schema.
 
-Three of the audit's findings are answered by running the gate, not by
-reasoning:
+Named fixtures cover every former frontend synthesis: helping vowels in all
+qualities, 3:1 iltiqa insertion, divine-name dagger alif, madd iwad at pause,
+dropped silah, taa marbuta, iqlab noon and small meem, and each muqattaat
+opening.
 
-- **F9 -- `vowel_silent`.** Enumerate, over the whole corpus, which `Rule`
-  appears on the `Silent` attribution of every unit legacy tagged
-  `vowel_silent`. If the set is small and named, the catch-all is retired and
-  the frontend tooltip splits. If any unit has no rule, the model has a silent
-  hole and that is a correctness bug, not a projection one.
-- **F10 -- the iqlab small meem.** Does any `Glyph` with `char == "ۢ"` have
-  a non-empty `units`? One query.
-- **F6 -- `write` totality.** ADR-005 §4's trigger set, asserted as
-  `unit.glyphs != ""` over the whole corpus at all three waqf levels. This is
-  the phase-2 gate that ADR-005 says must pass before "no fourth layer" is a
-  decision rather than a hypothesis.
+## 4. Graph completeness laws
 
-## 5. Order of work
+These laws run over the entire corpus in all three boundary modes.
 
-1. Resolve [03](../03-canonical-vocabulary.md). It blocks the `Unit` shape.
-2. **C1** -- label `Participants`. Mechanical, 21 sites, no behaviour change.
-3. **C2** -- keep the modifier edge. Small, and F1/F3 do not close without it.
-4. Build `Reading` over a single verse with a hand-written composition, and
-   check it against `tests/test_anchored_projection.py`'s six verses.
-5. **C3** -- the ref-to-document loop over `api.recitation` and
-   `plan_from_request`.
-6. `tools/projection_parity.py`, `silent_flags` adapter first.
-7. The other three adapters, largest last.
-8. Bump `out/phonemized_v{N+1}` and write the `changes.txt` entry.
+### 4.1 Envelope and indices
 
-Steps 1-4 are design closure. 5 onward is the gate.
+- `schema_version`, request identity, canonical selection, boundary plan, and
+  `score_digest` are present.
+- Canonical serialization of the same request is byte-stable.
+- Every index is in range and points to the declared node kind.
+- Node order is reading order and one index space spans the whole request.
+- Changing riwayah, selection, boundary plan, notation, or Score changes the
+  corresponding identity field; caches cannot alias the documents.
+
+### 4.2 Spelling
+
+- Every source scalar produces exactly one `Glyph` node.
+- Every glyph participates in at least one spelling edge.
+- `Structural` glyphs have `word=None` and no unit-bearing spelling edge.
+- Every `Evidences` edge has the correct `SlotFact`.
+- Every `Attests` edge names a valid family and anchor.
+- Every `Decorates` edge names the unit it visually marks.
+- Many-to-many edges for long-vowel carriers, tanween, and muqattaat are
+  present rather than collapsed.
+- Every iqlab small meem is bound by its intended typed edge.
+
+### 4.3 Attribution
+
+- For each unit and each applicable `Aspect`, exactly one performed outcome is
+  stated: hosted, merged, or silent.
+- Every sound has exactly one primary origin: one `Hosts` edge or one
+  `Inserted` edge. `MergedInto` never becomes a second owner.
+- Every insertion has a valid anchor, side, aspect, sound, and occurrence.
+- Every merger has a `Hosts` and `MergedInto` pair sharing sound and
+  occurrence, with distinct host and contributor units.
+- Every silence has an occurrence reason and no sound.
+- Joint hosts preserve all participating units.
+- The final-consonant pause fixture proves that an onset can host while the
+  same unit's nucleus is silent.
+
+### 4.4 Occurrences, participants, and modifiers
+
+- Every occurrence has valid, ordered, rule-legal participant roles.
+- Every target participant is reached by an attribution or modifier when the
+  rule changes or classifies a sound.
+- Every applied `Recolour` and `Relength` has exactly one retained modifier
+  edge with its value.
+- Every classification-only rule that names a sound has a `Classifies` edge.
+- Soundless ishmam has a target participant and no fabricated sound.
+- `FAMILY_OF` and `PHASE_OF` are total for every public `Rule`.
+- Deriving reverse indexes introduces no duplicate or dangling relation.
+
+### 4.5 Recited writing
+
+- `write` is total for every unit that has a recited representation.
+- Every rendered glyph links either to source spelling edges or to one
+  inserted sound and its anchor side.
+- Source glyph order and values never change.
+- An insertion needs neither a fake unit nor `char=""`.
+- Source and rendered strings reproduce every legacy `present`, `inserted`,
+  `dropped`, `replaced`, and `shortened` case through the definitions in
+  01-design.
+
+## 5. Schema and negative tests
+
+The JSON schema uses tagged unions for nucleus, sound, spelling, attribution,
+and modifier values. Tests reject at least:
+
+- a nullable quality paired with an incompatible nucleus kind;
+- a sound with fields from two sound variants;
+- `Structural` carrying a unit or word;
+- `Evidences` without a fact;
+- `Inserted` without a side;
+- `Silent` carrying a sound;
+- an attribution without `Aspect`;
+- a merger without its matching host;
+- an out-of-range or wrong-kind index;
+- duplicate canonical relations;
+- an unknown schema version.
+
+Round-trip tests cover canonical JSON, optional SDK-derived indexes, and schema
+evolution. Adding a union member requires a schema-version change and a
+negative test showing older readers fail clearly rather than misinterpret it.
+
+## 6. Domain fixture spine
+
+Small fixtures make failures diagnosable before the full-corpus run:
+
+| Case | What it proves |
+|---|---|
+| final consonant at pause | onset realization and nucleus silence coexist |
+| long vowel | haraka and carrier keep distinct spelling facts on one unit |
+| tanween | one grapheme reaches the base and the derived nunation unit |
+| muqattaat | compact script expands through many-to-many evidence |
+| cross-word idgham | host and contributor share sound and occurrence |
+| 3:1 iltiqa | slotless insertion keeps before/after placement |
+| silah joined and paused | conditional nucleus has two valid performances |
+| madd iwad | boundary-conditional length without a duration fact |
+| iqlab small meem | script witness remains bound without frontend surgery |
+| stop sign and verse marker | structural glyph belongs to no word or unit |
+| divine-name lam | lexical identity and tafkheem occurrence remain separate |
+| imala and ishmam | processes are occurrences; soundless gesture stays soundless |
+
+## 7. Order and CI policy
+
+1. Implement C1 and C2 with their local laws.
+2. Define the versioned JSON schema and negative tests.
+3. Assemble a single-verse `Reading` and pass the domain fixture spine.
+4. Implement C3 for ranges, internal boundaries, and selections.
+5. Implement `tools/projection_parity.py`; verify the frozen manifest.
+6. Pass each exact adapter in continuous, verse, and word modes.
+7. Pass the extended request matrix and full graph-completeness suite.
+
+A small deterministic sample and all negative tests run on every pull request.
+The full `1-114` matrix is required before the public replacement merges. CI
+publishes the structured residue report even on success; merge requires zero
+unexplained residues and a corrections ledger whose entries all have domain
+tests.

--- a/docs/design/projections/02-equivalence-gate.md
+++ b/docs/design/projections/02-equivalence-gate.md
@@ -105,10 +105,15 @@ suite separately proves the new facts exist.
 For each non-structural source token:
 
 ```text
-units  = units reached by its Evidences and Decorates edges
-silent = every relevant attributed aspect has a Silent outcome
-mark   = the adjacent silence-sign glyph bound to the same unit, or ""
+links  = contribution edges for the token's source glyphs
+silent = the legacy silence policy over Presents targets and OrthographicOnly
+mark   = the silence-sign glyph presenting the same outcome, or ""
 ```
+
+The policy distinguishes `Presents(Hosts)`, `Presents(Silent)`,
+`Presents(MergedInto)`, and `OrthographicOnly`; it never infers glyph
+audibility from whether a related unit has any sound. This is what makes the
+carrier waw silent while the dagger on the same nucleus remains sounded.
 
 The adapter then applies the legacy scalar grouping exactly: dagger alif,
 mini-waw, and mini-yaa remain separate where legacy separated them; other
@@ -119,15 +124,17 @@ combining marks rejoin their base. The following named cases must be exact:
 - taa marbuta at pause;
 - all legacy `vowel_silent` rows.
 
-Every silent outcome must name an occurrence. The residue report groups
-`vowel_silent` by the actual rule and fails if any row has no reason.
+Every `Presents(Silent)` outcome must name an occurrence.
+`OrthographicOnly` instead keeps its script reason in the glyph's spelling
+edges; it does not fabricate a performance occurrence. The residue report
+groups `vowel_silent` by the typed case and fails if any row has neither.
 
 ### 3.3 `tajweed_mappings`
 
-Occurrence participants supply trigger, target, and context; spelling edges
-locate the source glyphs; attribution and modifier edges locate the affected
-sound. A versioned vocabulary table maps the current `Rule` to the legacy
-rule names and trigger splits.
+Occurrence participants supply trigger, source, target, and context anchors;
+contribution edges locate the source glyphs; attribution and modifier edges
+locate the affected sound. A versioned vocabulary table maps the current
+`Rule` to the legacy rule names and trigger splits.
 
 Source and target are reconstructed from semantic roles, not tuple position.
 For assimilation, the disappearing trigger and receiving target are distinct
@@ -163,12 +170,12 @@ Every legacy field is adapted:
 |---|---|
 | `chars` | source spelling or derived recited writing |
 | `role` | folded `GraphemeClass` |
-| `status` | typed attribution plus source/rendered difference |
-| `phonemes` | attributed sound tokens |
+| `status` | typed glyph contribution plus source/rendered difference |
+| `phonemes` | sound targets reached by glyph contribution |
 | `phoneme_indices` | sound indices rebased word-local |
 | `tag` | legacy priority over compatible occurrences |
 | `secondary_tags` | remaining compatible occurrences |
-| `phoneme_rule_tags` | occurrences reached by attribution and modifier edges |
+| `phoneme_rule_tags` | occurrences reached by contribution, attribution, and modifier edges |
 | `share_group` | units on joint or shared sound relations |
 | `source_letter_index` | source glyph index |
 | `source_letter_indices` | spelling edges back to source glyphs |
@@ -198,6 +205,9 @@ These laws run over the entire corpus in all three boundary modes.
 ### 4.2 Spelling
 
 - Every source scalar produces exactly one `Glyph` node.
+- Concatenating `glyph.char` in `source_index` order reproduces the requested
+  source text as the exact Unicode scalar sequence, including internal spaces
+  and structural marks.
 - Every glyph participates in at least one spelling edge.
 - `Structural` glyphs have `word=None` and no unit-bearing spelling edge.
 - Every `Evidences` edge has the correct `SlotFact`.
@@ -223,7 +233,9 @@ These laws run over the entire corpus in all three boundary modes.
 
 ### 4.4 Occurrences, participants, and modifiers
 
-- Every occurrence has valid, ordered, rule-legal participant roles.
+- Every participant names a valid `(unit, Aspect)` anchor.
+- Every occurrence has valid, ordered roles under its rule family's schema,
+  including required and repeatable role cardinalities.
 - Every target participant is reached by an attribution or modifier when the
   rule changes or classifies a sound.
 - Every applied `Recolour` and `Relength` has exactly one retained modifier
@@ -233,11 +245,27 @@ These laws run over the entire corpus in all three boundary modes.
 - `FAMILY_OF` and `PHASE_OF` are total for every public `Rule`.
 - Deriving reverse indexes introduces no duplicate or dangling relation.
 
-### 4.5 Recited writing
+### 4.5 Glyph contribution
+
+- Every non-structural glyph has one or more `Presents` edges or exactly one
+  `OrthographicOnly` edge, never both.
+- Every `Presents` target resolves to an attribution, modifier, or occurrence
+  and is compatible with the glyph's spelling edges.
+- Structural glyphs have no contribution edge.
+- A haraka and ordinary carrier may both present one hosted nucleus sound.
+- A carrier under a dagger is `OrthographicOnly`; the dagger presents the
+  hosted nucleus sound.
+- A maddah may present a performance target even though `Decorates` supplies
+  no canonical fact.
+- A soundless process mark may present its occurrence without a fabricated
+  sound.
+- No adapter or serializer infers glyph audibility from unit audibility.
+
+### 4.6 Recited writing
 
 - `write` is total for every unit that has a recited representation.
-- Every rendered glyph links either to source spelling edges or to one
-  inserted sound and its anchor side.
+- Every rendered glyph links either to source contribution and spelling edges
+  or to one inserted sound and its anchor side.
 - Source glyph order and values never change.
 - An insertion needs neither a fake unit nor `char=""`.
 - Source and rendered strings reproduce every legacy `present`, `inserted`,
@@ -247,7 +275,7 @@ These laws run over the entire corpus in all three boundary modes.
 ## 5. Schema and negative tests
 
 The JSON schema uses tagged unions for nucleus, sound, spelling, attribution,
-and modifier values. Tests reject at least:
+modifier, and glyph-contribution values. Tests reject at least:
 
 - a nullable quality paired with an incompatible nucleus kind;
 - a sound with fields from two sound variants;
@@ -257,6 +285,9 @@ and modifier values. Tests reject at least:
 - `Silent` carrying a sound;
 - an attribution without `Aspect`;
 - a merger without its matching host;
+- a `Presents` edge with an out-of-range or wrong-kind target;
+- a glyph carrying both `Presents` and `OrthographicOnly`;
+- a non-structural glyph with no contribution edge;
 - an out-of-range or wrong-kind index;
 - duplicate canonical relations;
 - an unknown schema version.
@@ -265,31 +296,42 @@ Round-trip tests cover canonical JSON, optional SDK-derived indexes, and schema
 evolution. Adding a union member requires a schema-version change and a
 negative test showing older readers fail clearly rather than misinterpret it.
 
-## 6. Domain fixture spine
+## 6. Domain adequacy matrix
 
-Small fixtures make failures diagnosable before the full-corpus run:
+Each applicable family has joined, stopped, and started fixtures. An
+unmodelled relationship blocks the contract; an adapter or serializer may not
+repair it.
 
-| Case | What it proves |
+| Family | Relationships that must be represented |
 |---|---|
-| final consonant at pause | onset realization and nucleus silence coexist |
-| long vowel | haraka and carrier keep distinct spelling facts on one unit |
-| tanween | one grapheme reaches the base and the derived nunation unit |
-| muqattaat | compact script expands through many-to-many evidence |
-| cross-word idgham | host and contributor share sound and occurrence |
-| 3:1 iltiqa | slotless insertion keeps before/after placement |
-| silah joined and paused | conditional nucleus has two valid performances |
-| madd iwad | boundary-conditional length without a duration fact |
-| iqlab small meem | script witness remains bound without frontend surgery |
-| stop sign and verse marker | structural glyph belongs to no word or unit |
-| divine-name lam | lexical identity and tafkheem occurrence remain separate |
-| imala and ishmam | processes are occurrences; soundless gesture stays soundless |
+| short and long vowels | base, haraka, carrier fan-in, shared sound, and distinct glyph contribution |
+| silent carriers | otiose alif, waw, yaa, and maqsura; silence sign; dagger seat versus sounded dagger |
+| hamza wasl | source glyph, start vowel, joined deletion, repair, and article lam |
+| tanween | one mark to vowel and nunation anchors; continuing carrier silence; waqf iwad |
+| silah | written or virtual extension, joined length, and pausal deletion |
+| divine name | word lexical class, heavy or light lam occurrence, written or virtual dagger, and waqf change |
+| mergers | within-word and cross-word source, host, contributor, shared sound, complete and partial forms |
+| noon and meem | source, trigger, target roles and nasal placement for noon, tanween, and meem |
+| madd | haraka, carrier, mark, subtype, participant-derived cause, and boundary change |
+| qalqala | closure and release, one occurrence, consonant reach, and stop degree |
+| emphasis | consonant and governed vowel reach, including raa and divine-name cases |
+| muqattaat | compact glyph to spelled units, sounds, and rules without a cached mapping |
+| waqf endings | nucleus deletion with onset retained, ta marbuta, iwad, arid, leen, and qalqala |
+| ibtida | start boundary, wasl vowel, gemination, and right context |
+| marks and advice | imala, ishmam, tashil, sakt, seen/sad, iqlab, maddah, and stop advice |
+| slotless repair | side, order, occurrence, sound, contribution-free insertion, and rendered form |
+| source structure | spaces, internal spaces, tatweel, stop signs, and verse markers round-trip exactly |
+
+Madd cause is required through rule and participant semantics. Permitted and
+selected counts remain outside this contract until request identity includes
+the transmission path or realization policy that makes them authoritative.
 
 ## 7. Order and CI policy
 
-1. Implement C1 and C2 with their local laws.
+1. Implement C1-C3 with their local laws.
 2. Define the versioned JSON schema and negative tests.
-3. Assemble a single-verse `Reading` and pass the domain fixture spine.
-4. Implement C3 for ranges, internal boundaries, and selections.
+3. Assemble a single-verse `Reading` and pass the domain adequacy matrix.
+4. Implement C4 for ranges, internal boundaries, and selections.
 5. Implement `tools/projection_parity.py`; verify the frozen manifest.
 6. Pass each exact adapter in continuous, verse, and word modes.
 7. Pass the extended request matrix and full graph-completeness suite.

--- a/docs/design/projections/README.md
+++ b/docs/design/projections/README.md
@@ -6,15 +6,17 @@ public projection API out of scope. This is that API.
 | | Document | Answers |
 |---|---|---|
 | [00](00-audit.md) | Audit | What the four legacy projections published, which consumer read what, where consumers invent facts, and what the layered model still cannot say |
-| [01](01-design.md) | Design | Two projections; the key is a unit, not a character; the three model changes it needs |
-| [02](02-equivalence-gate.md) | Gate | How replacement is proven not to lose anything |
+| [01](01-design.md) | Design | Two projections over typed nodes, spelling, attribution, and modifier edges |
+| [02](02-equivalence-gate.md) | Gate | Exact legacy adapters plus laws for the richer graph |
 
 Scope: Uthmani, Hafs. IndoPak is deferred and nothing here depends on it.
 
-Assumes [03-canonical-vocabulary](../03-canonical-vocabulary.md) resolved.
+Assumes [03-canonical-vocabulary](../03-canonical-vocabulary.md) resolved and
+follows [ADR-013](../../adr/013-public-projection-foundations.md).
 
-The one-paragraph version: the four legacy projections were four traversals of a
-join that the old model could not hold, so each recomputed the relationships
-from rule names and each lost a different set of them. The layered model *is*
-the join. One document -- `Reading` -- publishes it as five node arrays keyed on
-the `Slot`, and `phonemes` stays separate for the consumers who want only sound.
+The one-paragraph version: the four legacy projections were four traversals of
+a join that the old model could not hold, so each recomputed relationships from
+rule names and lost a different set. The layered model is the join. `Reading`
+publishes its five ordered node arrays and its typed spelling, attribution, and
+modifier edges without duplicate reverse links. `phonemes` stays separate for
+consumers that want only sound.

--- a/docs/design/projections/README.md
+++ b/docs/design/projections/README.md
@@ -6,7 +6,7 @@ public projection API out of scope. This is that API.
 | | Document | Answers |
 |---|---|---|
 | [00](00-audit.md) | Audit | What the four legacy projections published, which consumer read what, where consumers invent facts, and what the layered model still cannot say |
-| [01](01-design.md) | Design | Two projections over typed nodes, spelling, attribution, and modifier edges |
+| [01](01-design.md) | Design | Two projections over typed nodes and four lossless relation families |
 | [02](02-equivalence-gate.md) | Gate | Exact legacy adapters plus laws for the richer graph |
 
 Scope: Uthmani, Hafs. IndoPak is deferred and nothing here depends on it.
@@ -18,5 +18,5 @@ The one-paragraph version: the four legacy projections were four traversals of
 a join that the old model could not hold, so each recomputed relationships from
 rule names and lost a different set. The layered model is the join. `Reading`
 publishes its five ordered node arrays and its typed spelling, attribution, and
-modifier edges without duplicate reverse links. `phonemes` stays separate for
-consumers that want only sound.
+modifier edges, plus explicit glyph contribution, without duplicate reverse
+links. `phonemes` stays separate for consumers that want only sound.


### PR DESCRIPTION
This reconciles #48 with the normalized relational core explored in #47. It keeps #48's identified Reading snapshot, conditional nuclei, recited-writing separation, and migration strategy, while preserving the model's typed Spelling and aspect-bearing Attribution unions instead of flattening relationships onto nodes. Modifier provenance is retained as a third edge family, reverse indexes and rule family/phase are derived, IDs are request-local, and lexical identity is separated from imala and ishmam processes.

The equivalence gate now uses the committed legacy manifest in continuous, verse, and word modes; requires row-for-row compatibility for every preserved legacy view; and replaces the broad additive exemption with graph-completeness laws, negative schema tests, and named domain fixtures. ADR-013 records the reconciliation and explicitly amends the conflicting pending vocabulary decision while reaffirming ADR-002 and ADR-003.

Validated with 281 passing tests (1 skipped), comment and structure linters, Markdown link checks, ASCII checks, and git diff checks.