### PR TITLE
Fix the joined-reading regressions the whole-corpus audit found

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -62,7 +62,7 @@ jobs:
   regression:
     # Not a target. The oracle is the previous implementation with its defects
     # frozen in, so this is a change detector and its floor may fall when the
-    # oracle is the one that is wrong. All 56 rows are classified in
+    # oracle is the one that is wrong. All 61 rows are classified in
     # docs/conformance/gate-residues.md, with the evidence for each direction.
     runs-on: ubuntu-latest
     steps:
@@ -73,8 +73,8 @@ jobs:
       - run: pip install -e .
       - name: regression oracle, both modes
         run: |
-          python tools/floor.py regression word 99.928
-          python tools/floor.py regression verse 97.674
+          python tools/floor.py regression word 99.921
+          python tools/floor.py regression verse 97.852
 
   roundtrip:
     # Every Score can be spelled and spells back to itself. Closed: no Score
@@ -100,8 +100,8 @@ jobs:
       - run: pip install -e .
       - name: unmet attestations, both scripts
         run: |
-          python tools/floor.py attest uthmani 178
-          python tools/floor.py attest indopak 239
+          python tools/floor.py attest uthmani 176
+          python tools/floor.py attest indopak 237
 
   l1:
     # Score-level script equality. The ceiling stops the residue growing.

--- a/docs/conformance/gate-residues.md
+++ b/docs/conformance/gate-residues.md
@@ -9,10 +9,10 @@ can be checked rather than a number nobody looks at.
 | cross-script, word | 99.997% | 2 words |
 | cross-script, verse | **100.000%** | none |
 | round-trip, uthmani | **100.000%** | none |
-| regression, word | 99.928% | 56 words |
-| regression, verse | 97.674% | see below |
+| regression, word | 99.921% | 61 words |
+| regression, verse | 97.852% | see below |
 | L1 | 18 rows over 287,057 slots | |
-| attestations | 178 uthmani, 239 indopak | |
+| attestations | 176 uthmani, 237 indopak | |
 
 ## Cross-script — 2 words
 
@@ -25,7 +25,7 @@ forces separates them.
 | 26:61:2 | `تَرَآءَا` | `تَرَآءَ` | `tarˤaˤ:ʔa lʒamʕa:ni` both |
 | 59:9:2 | `تَبَوَّءُو` | `تَبَوَّءُ` | `tabawwaʔu dda:rˤaˤ` both |
 
-## Regression — 56 words
+## Regression — 61 words
 
 The oracle is the previous implementation with its own defects frozen in, so
 this gate is a change detector and not a target. Every row is one of five
@@ -58,6 +58,15 @@ quiescent after a damma, which is madd tabii by definition. The oracle
 answers this shape two ways: `هُوَ` gives `hu:` and `يَعْفُوَا۟` gives
 `jaʕfuw`, so it contradicts itself rather than us.
 
+**5 — form VIII with lam for its first radical** (`ٱلْتَقَى` ×3,
+`ٱلْتَقَتَا`, `ٱلْتَقَيْتُمْ`). Started on, the oracle gives `ʔaltaqaa`. Fatha is
+the article's helping vowel and the article makes nouns; these are verbs, and
+a verb takes a damma only when its third letter carries one. The third letter
+here carries a fatha, so the prosthetic hamza takes a kasra: `ʔiltaqaa`. What
+separates them from `ٱلتَّقْوَىٰ` is written in both scripts -- taa is a sun
+letter, so the article before one always spells the shadda of its
+assimilation, and these words have none.
+
 **5 — the dual construct** (`طَرَفَىِ`, `يَـٰصَـٰحِبَىِ` ×2, `يَدَىِ`,
 `ثُلُثَىِ`). The kasra on the yaa is there to meet the wasl hamza of the next
 word, which is what proves the yaa is a consonant. Stopping gives `-ay`; the
@@ -65,5 +74,7 @@ oracle's `-aa` is the nominative of a word standing in the genitive.
 
 ## Verse mode
 
-The same classes, plus the rows where a word-mode difference propagates into
-its neighbour once the words are joined.
+97.852% counts a word wrong when a sound merged across a boundary is credited
+to the neighbour; the harness prints the phoneme sequence separately, and
+that is 77,432 of 77,433. The one word left is `يَسْرِ` at 89:4, already
+listed above under the disputed raa.

--- a/quranic_phonemizer/canon/derive/wasl.py
+++ b/quranic_phonemizer/canon/derive/wasl.py
@@ -149,9 +149,34 @@ def helping_vowel(context: Context) -> Quality:
     return _helping_vowel(context)
 
 
+def _form_eight_lam(context: Context) -> bool:
+    """`ٱلْتَقَى` against `ٱلتَّقْوَىٰ`: a verb whose first radical is the lam."""
+    # Taa is a sun letter, so the article before one always writes the shadda
+    # of its assimilation, in either script. A bare taa after a quiescent lam
+    # therefore cannot be the article, and the only Arabic that puts one there
+    # is form VIII with lam for its first radical. `rules/` has to keep a
+    # lexeme list for the same question because the Score holds no shadda --
+    # the article's gemination is attested there, not canonical.
+    following, third = context.ahead(), context.ahead(2)
+    if following is None or following.has("shadda", *VOWEL_ROLES):
+        return False  # `ٱلَّتِى` doubles its lam, so the lam is not quiescent
+    return (
+        third is not None
+        and third.letter is CanonLetter.TA
+        and not third.has("shadda")
+    )
+
+
 def _helping_vowel(context: Context) -> Quality:
     following = context.ahead()
-    if following is not None and following.letter is CanonLetter.LAM:
+    if (
+        following is not None
+        and following.letter is CanonLetter.LAM
+        and not _form_eight_lam(context)
+    ):
+        # Fatha is the article's, and the article makes nouns. A verb takes a
+        # damma when its third letter carries one and a kasra otherwise, which
+        # is what the two branches below decide.
         return Quality.A
     if context.lexicon.takes_wasl_kasra(_skeleton(context)):
         return Quality.I

--- a/quranic_phonemizer/canon/lexicon.py
+++ b/quranic_phonemizer/canon/lexicon.py
@@ -50,11 +50,22 @@ class Section:
 
 
 @dataclass(frozen=True, slots=True)
+class Affixes:
+    """What may attach to a lexeme and leave it that lexeme. Arabic, so it
+    is shared data rather than a set per riwayah."""
+
+    clitics: frozenset[str] = frozenset()
+    """The attached pronouns. A closed set, so a stem entry covers its whole
+    inflectional family without enumerating it."""
+    proclitics: frozenset[str] = frozenset()
+    """The single letters that may stand before a word. Closed for the same
+    reason, and what keeps `جَآءَنَا` from reading as `أَنَا` behind a prefix."""
+
+
+@dataclass(frozen=True, slots=True)
 class Lexicon:
     sections: dict[str, Section] = field(default_factory=dict)
-    clitics: frozenset[str] = frozenset()
-    """Arabic's attached pronouns. A closed set, so a stem entry covers its
-    whole inflectional family without enumerating it."""
+    affixes: Affixes = field(default_factory=Affixes)
     source: Path | None = field(default=None, compare=False)
 
     def is_divine_name(self, tail: str) -> bool:
@@ -94,32 +105,37 @@ class Lexicon:
         section = self.sections.get(name)
         if section is None:
             return False
-        return _MATCHERS[section.match](section.entries, key, self.clitics)
+        return _MATCHERS[section.match](section.entries, key, self.affixes)
 
 
-def _exact(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+def _exact(entries: frozenset[str], key: str, affixes: Affixes) -> bool:
     return key in entries
 
 
-def _clitic(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+def _clitic(entries: frozenset[str], key: str, affixes: Affixes) -> bool:
     """A lexeme, with or without a clitic pronoun."""
     return key in entries or any(
-        key == stem + clitic for stem in entries for clitic in clitics
+        key == stem + clitic for stem in entries for clitic in affixes.clitics
     )
 
 
-def _inflected(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
+def _inflected(entries: frozenset[str], key: str, affixes: Affixes) -> bool:
     """That, or a stem long enough to be specific as a prefix -- `ألقى`,
     `ألقينا`, `ألقوا` are one entry."""
-    return _clitic(entries, key, clitics) or any(
+    return _clitic(entries, key, affixes) or any(
         len(stem) >= _PREFIX_MIN and key.startswith(stem) for stem in entries
     )
 
 
-def _proclitic(entries: frozenset[str], key: str, clitics: frozenset[str]) -> bool:
-    return key in entries or any(
-        len(key) - len(entry) == _PROCLITIC and key.endswith(entry)
-        for entry in entries
+def _proclitic(entries: frozenset[str], key: str, affixes: Affixes) -> bool:
+    """A lexeme, or one behind a single proclitic: `وَأَنَا` is `أنا`."""
+    # The prefix has to *be* a proclitic, not merely two characters long: the
+    # vocalised notation writes no length, so `جَآءَنَا` and `وَأَنَا` are one
+    # shape to a counting test and only the letter tells them apart.
+    return key in entries or (
+        len(key) > _PROCLITIC
+        and key[0] in affixes.proclitics
+        and key[_PROCLITIC:] in entries
     )
 
 
@@ -161,7 +177,7 @@ def _section(raw, name: str, path: Path) -> Section:
     )
 
 
-def load_lexicon(path: Path, *, clitics: frozenset[str] = frozenset()) -> Lexicon:
+def load_lexicon(path: Path, *, affixes: Affixes = Affixes()) -> Lexicon:
     data = load_yaml(path)
     require_keys(data, {"schema_version", "sections"}, name=str(path))
     if data["schema_version"] != SCHEMA_VERSION:
@@ -176,18 +192,25 @@ def load_lexicon(path: Path, *, clitics: frozenset[str] = frozenset()) -> Lexico
         sections={
             name: _section(raw, name, path) for name, raw in sections.items()
         },
-        clitics=clitics,
+        affixes=affixes,
         source=path,
     )
 
 
-def load_clitic_pronouns(path: Path) -> frozenset[str]:
+def load_affixes(path: Path) -> Affixes:
     """Arabic morphology, invariant across riwayat, so it is shared data."""
     data = load_yaml(path)
-    require_keys(data, {"schema_version", "clitic_pronouns"}, name=str(path))
+    require_keys(
+        data,
+        {"schema_version", "clitic_pronouns", "proclitics"},
+        name=str(path),
+    )
     if data["schema_version"] != MORPHOLOGY_SCHEMA_VERSION:
         raise LexiconError(
             f"{path}: schema_version {data['schema_version']!r}, expected "
             f"{MORPHOLOGY_SCHEMA_VERSION}"
         )
-    return _entries(data["clitic_pronouns"], "clitic_pronouns", path)
+    return Affixes(
+        clitics=_entries(data["clitic_pronouns"], "clitic_pronouns", path),
+        proclitics=_entries(data["proclitics"], "proclitics", path),
+    )

--- a/quranic_phonemizer/canon/passes.py
+++ b/quranic_phonemizer/canon/passes.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from ..model.address import VariantSelection, VerseRef
+from ..model.address import VariantSelection
 from ..model.canon import (
     ABJAD,
     Annotation,
@@ -67,7 +67,7 @@ def apply_ledger(reading: Reading, drafts, ledger: Ledger, track) -> None:
     """
     _check_witnesses(reading, drafts, ledger)
     for supply in ledger.supplies:
-        if not _addresses(supply.ref, reading.verse):
+        if not _addresses(reading, supply.ref):
             continue
         ordinal = _resolve(reading, drafts, supply.ref)
         _check_skeleton(reading, drafts, ordinal, supply.skeleton)
@@ -81,7 +81,7 @@ def _check_witnesses(reading: Reading, drafts, ledger: Ledger) -> None:
     for row in ledger.asserts:
         if row.script is not reading.script:
             continue
-        if not _addresses(row.ref, reading.verse):
+        if not _addresses(reading, row.ref):
             continue
         ordinal = _resolve(reading, drafts, row.ref)
         _check_skeleton(reading, drafts, ordinal, row.skeleton)
@@ -112,22 +112,25 @@ def _resolve(reading: Reading, drafts, ref) -> int:
     return ordinal
 
 
-def _addresses(ref, verse: VerseRef) -> bool:
-    """Is this entry about this verse at all? Separating the two meanings of
-    an unresolved address is what lets the second one be loud."""
+def _addresses(reading: Reading, ref) -> bool:
+    """Is this entry about a word this reading holds? A reading carrying past
+    a verse end is one reading, so a word-scoped entry is sought among its
+    words, not against the one verse it is anchored at."""
+    # Separating the two meanings of an unresolved address -- not ours, and
+    # ours but broken -- is what lets the second one be loud.
     if isinstance(ref, VerseSlot):
-        return ref.verse == verse
-    return isinstance(ref, WordSlot) and ref.location.verse == verse
+        return ref.verse == reading.verse
+    return isinstance(ref, WordSlot) and ref.location in reading.words
 
 
 def _ordinal(reading: Reading, drafts, ref) -> int | None:
     """A verse-scoped ordinal is robust but unreadable, so entries may also
-    be written word-relative and are resolved to a verse ordinal here."""
+    be written word-relative and are resolved to a reading ordinal here."""
     if isinstance(ref, VerseSlot):
         return ref.ordinal if ref.verse == reading.verse else None
-    if not isinstance(ref, WordSlot) or ref.location.verse != reading.verse:
+    if not isinstance(ref, WordSlot) or ref.location not in reading.words:
         return None
-    word = ref.location.word - 1
+    word = reading.words.index(ref.location)
     span = [i for i, d in enumerate(drafts) if word_of(reading, d) == word]
     return span[ref.index] if 0 <= ref.index < len(span) else None
 

--- a/quranic_phonemizer/data/riwayat/hafs/ledger.yaml
+++ b/quranic_phonemizer/data/riwayat/hafs/ledger.yaml
@@ -77,6 +77,13 @@ supplies:
   - {slot: "83:14:2#1", skeleton: "بل", fact: SAKT, value: true,
      citation: "Hafs; sakt, 4 of 4"}
 
+  # 69:28-29 `مَالِيَهْ ۜ هَلَكَ` is the fifth site, and the one the sources argue
+  # over: the two haas would otherwise merge, and Hafs by the Shatibiyyah
+  # keeps the first clear. Listed here rather than among the four above
+  # because it is a decision this package makes, not one every source shares.
+  - {slot: "69:28:4#3", skeleton: "مليه", fact: SAKT, value: true,
+     citation: "Hafs; sakt on مَالِيَهْ, izhar of the two haas"}
+
 asserts:
   - {script: uthmani, slot: "6:77:2#1", skeleton: "رء", fact: NUCLEUS,
      value: {kind: Long, quality: A}}

--- a/quranic_phonemizer/data/shared/morphology.yaml
+++ b/quranic_phonemizer/data/shared/morphology.yaml
@@ -10,3 +10,9 @@ schema_version: 1
 # `إيمانهم` without either being listed.
 clitic_pronouns: ["ه", "هم", "هما", "هن", "ك", "كم", "كما", "كن", "نا", "ي",
                   "ني", "همء"]
+
+# The single letters that may stand before a word without changing which word
+# it is: the two conjunctions, the preposition and the two particles. Also a
+# closed class, and what tells `وَأَنَا` -- `أنا` behind a proclitic -- from
+# `جَآءَنَا`, which merely ends in the same letters and vowels.
+proclitics: ["و", "ف", "ب", "ل", "ك"]

--- a/quranic_phonemizer/data/shared/rules.yaml
+++ b/quranic_phonemizer/data/shared/rules.yaml
@@ -42,6 +42,9 @@ proclitics: [و, ف]
 pairs:
   idgham_mutajanisayn_kamil:
     - [د, ت]
+    # `أَثْقَلَت دَّعَوَا` (7:189), `أُجِيبَت دَّعْوَتُكُمَا` (10:89). The pair runs
+    # both ways: taa and dal share a place, so either merges into the other.
+    - [ت, د]
     - [ت, ط]
     - [ذ, ظ]
     - [ث, ذ]

--- a/quranic_phonemizer/engine/neighbourhood.py
+++ b/quranic_phonemizer/engine/neighbourhood.py
@@ -76,6 +76,11 @@ class Neighbourhood:
         left, right = self._word.get(here), self._word.get(following)
         if left is None or right is None or left == right:
             return False
+        if self.score.words[left].sakt_after:
+            # A sakt is a silence, so nothing carries across it. It is a Score
+            # fact rather than a requested stop, and holds under any plan --
+            # a caller that asks to join everything still cannot join `مَنْ ۜ رَاقٍ`.
+            return True
         return self.boundaries.junctions[left] in (
             Junction.STOP,
             Junction.SAKT,

--- a/quranic_phonemizer/engine/neighbourhood.py
+++ b/quranic_phonemizer/engine/neighbourhood.py
@@ -76,6 +76,13 @@ class Neighbourhood:
         left, right = self._word.get(here), self._word.get(following)
         if left is None or right is None or left == right:
             return False
+        if self._spelled_out(left):
+            # An opening of named letters ends as it would at a pause, however
+            # the reading runs on: `نٓ وَٱلْقَلَمِ` keeps a clear noon and a plain
+            # waw, and `طسٓ تِلْكَ` hides nothing. A name is spelled, not read,
+            # so it does not run into the word after it. Only forward: a word
+            # before an opening still meets it as an ordinary word.
+            return True
         if self.score.words[left].sakt_after:
             # A sakt is a silence, so nothing carries across it. It is a Score
             # fact rather than a requested stop, and holds under any plan --
@@ -86,3 +93,8 @@ class Neighbourhood:
             Junction.SAKT,
             Junction.EDGE,
         )
+
+    def _spelled_out(self, word: int) -> bool:
+        """A muqattaat opening: every slot of it is a letter's name."""
+        slots = self.score.words[word].slots
+        return bool(slots) and all(slot.spelled for slot in slots)

--- a/quranic_phonemizer/model/canon.py
+++ b/quranic_phonemizer/model/canon.py
@@ -359,7 +359,9 @@ CLASSIFICATION_ONLY: frozenset[Rule] = frozenset(
         Rule.ILTIQA_REPAIR,
         Rule.PAUSAL_ALIF,
         # Both emit `Relength`, which modifies a sound rather than producing
-        # one - the same footing as TAFKHEEM/TARQEEQ.
+        # one - the same footing as TAFKHEEM/TARQEEQ. Listing a rule here
+        # permits an occurrence with no attribution; it does not forbid one,
+        # so the tanween half of ILTIQA_REPAIR may still realize its kasra.
         Rule.IMALA,
         Rule.TASHIL,
         Rule.ISHMAM,

--- a/quranic_phonemizer/model/canon.py
+++ b/quranic_phonemizer/model/canon.py
@@ -280,6 +280,7 @@ class Rule(StrEnum):
     WASL_START = "wasl_start"
     ILTIQA_REPAIR = "iltiqa_repair"
     WAQF_ENDING = "waqf_ending"
+    PAUSAL_ALIF = "pausal_alif"
     SILAH = "silah"
     SAKT = "sakt"
 
@@ -325,6 +326,7 @@ FAMILY_OF: dict[Rule, RuleFamily] = {
     Rule.WASL_START: RuleFamily.INSERTION,
     Rule.ILTIQA_REPAIR: RuleFamily.INSERTION,
     Rule.WAQF_ENDING: RuleFamily.ELISION,
+    Rule.PAUSAL_ALIF: RuleFamily.ELISION,
     Rule.SILAH: RuleFamily.LENGTHENING,
     Rule.SAKT: RuleFamily.RELEASE,
     Rule.PLAIN: RuleFamily.ELISION,
@@ -355,7 +357,8 @@ CLASSIFICATION_ONLY: frozenset[Rule] = frozenset(
         Rule.MADD_ARID_LIL_SUKUN,
         Rule.MADD_LEEN,
         Rule.ILTIQA_REPAIR,
-        # Emits `Relength`, which modifies a sound rather than producing
+        Rule.PAUSAL_ALIF,
+        # Both emit `Relength`, which modifies a sound rather than producing
         # one - the same footing as TAFKHEEM/TARQEEQ.
         Rule.IMALA,
         Rule.TASHIL,

--- a/quranic_phonemizer/riwayat/hafs/resources.py
+++ b/quranic_phonemizer/riwayat/hafs/resources.py
@@ -13,7 +13,7 @@ from ...canon import derive
 from ...canon.ledger import EMPTY as EMPTY_LEDGER
 from ...canon.ledger import Ledger, load_ledger
 from ...canon.lexicon import EMPTY as EMPTY_LEXICON
-from ...canon.lexicon import Lexicon, load_clitic_pronouns, load_lexicon
+from ...canon.lexicon import Lexicon, load_affixes, load_lexicon
 from ...canon.spell import Muqattaat, load_muqattaat
 from ...corpus import PackedCorpus, load_corpus
 from ...model.address import Location, Riwayah, Script, VerseRef
@@ -80,13 +80,14 @@ def ledger() -> Ledger:
 
 
 def lexicon() -> Lexicon:
-    """The clitic pronouns are shared: which pronouns attach to a word is a
-    fact about Arabic, not about how this riwayah recites it."""
+    """The affixes are shared: which pronouns attach to a word, and which
+    letters may stand before one, are facts about Arabic rather than about
+    how this riwayah recites it."""
     path = DATA / "lexicon.yaml"
     if not path.exists():
         return EMPTY_LEXICON
-    clitics = load_clitic_pronouns(DATA.parents[1] / "shared" / "morphology.yaml")
-    return load_lexicon(path, clitics=clitics)
+    affixes = load_affixes(DATA.parents[1] / "shared" / "morphology.yaml")
+    return load_lexicon(path, affixes=affixes)
 
 
 def rule_tables() -> RuleTables:

--- a/quranic_phonemizer/riwayat/hafs/rules.py
+++ b/quranic_phonemizer/riwayat/hafs/rules.py
@@ -14,6 +14,7 @@ from ...rules.boundary import (
     SoftenedHamza,
     TaaMarbutaAtWaqf,
     TanweenAtWaqf,
+    TanweenBeforeWasl,
     WaqfEnding,
     WaslHamza,
 )
@@ -38,6 +39,7 @@ def _build() -> RuleSet:
         {
             Phase.BOUNDARY: (
                 WaslHamza(), SoftenedHamza(), TanweenAtWaqf(), PausalAlif(),
+                TanweenBeforeWasl(),
                 WaqfEnding(yaa=khilaf().yaa),
                 TaaMarbutaAtWaqf(), Sakt(),
             ),

--- a/quranic_phonemizer/riwayat/hafs/rules.py
+++ b/quranic_phonemizer/riwayat/hafs/rules.py
@@ -10,6 +10,7 @@ from ...model.address import Riwayah
 from ...model.canon import Phase
 from ...rules.annotation import CanonicalColour, Sakt, Silah, Tarqeeq
 from ...rules.boundary import (
+    PausalAlif,
     SoftenedHamza,
     TaaMarbutaAtWaqf,
     TanweenAtWaqf,
@@ -36,7 +37,7 @@ def _build() -> RuleSet:
     return RuleSet(
         {
             Phase.BOUNDARY: (
-                WaslHamza(), SoftenedHamza(), TanweenAtWaqf(),
+                WaslHamza(), SoftenedHamza(), TanweenAtWaqf(), PausalAlif(),
                 WaqfEnding(yaa=khilaf().yaa),
                 TaaMarbutaAtWaqf(), Sakt(),
             ),

--- a/quranic_phonemizer/rules/boundary.py
+++ b/quranic_phonemizer/rules/boundary.py
@@ -172,6 +172,41 @@ class SoftenedHamza:
 
 
 @dataclass(frozen=True, slots=True)
+class TanweenBeforeWasl:
+    """A tanween noon grows a kasra to reach the word after it."""
+    # `خَيْرٌ ٱهْبِطُوا۟` joins a quiescent noon to the quiescent letter the elided
+    # prosthetic hamza leaves bare, and two of them cannot meet: the noon
+    # takes the kasra that breaks them. The other half of the same repair
+    # shortens a madd instead -- see `rules/madd.py::IltiqaRepair`.
+
+    rule: Rule = Rule.ILTIQA_REPAIR
+    phase: Phase = Phase.BOUNDARY
+    triggers: frozenset = frozenset({CanonLetter.NOON})
+
+    def look(
+        self, near: Neighbourhood, plan: Plan, at: SlotId,
+        boundaries: BoundaryPlan,
+    ) -> Verdict | None:
+        del plan, boundaries
+        slot = near.slot(at)
+        if slot is None or slot.origin is not SlotOrigin.NUNATION:
+            return None
+        if not near.last_of_word(at):
+            return None
+        # `after` is `None` at a stop, where `TanweenAtWaqf` owns the noon.
+        following = near.after(at)
+        if following is None or following.onset is not Onset.WASL:
+            return None
+        return Verdict(
+            Occurrence(
+                mint(Rule.ILTIQA_REPAIR, at, variant=1), Rule.ILTIQA_REPAIR,
+                Participants((at, following.id)),
+            ),
+            (Realize(at, Aspect.NUCLEUS, Vowel(Quality.I)),),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PausalAlif:
     """The seven alifs: long at a pause, short when the word is joined to.
 

--- a/quranic_phonemizer/rules/boundary.py
+++ b/quranic_phonemizer/rules/boundary.py
@@ -172,6 +172,41 @@ class SoftenedHamza:
 
 
 @dataclass(frozen=True, slots=True)
+class PausalAlif:
+    """The seven alifs: long at a pause, short when the word is joined to.
+
+    The mirror of `Onset.SILAH`, which `WaqfEnding` removes at a stop.
+    """
+    # Emits `Relength`, not a realization: the vowel is still plainly
+    # produced, and only its length changes.
+
+    rule: Rule = Rule.PAUSAL_ALIF
+    phase: Phase = Phase.BOUNDARY
+    triggers: frozenset = frozenset({NucleusKind.PAUSAL_LONG})
+
+    def look(
+        self, near: Neighbourhood, plan: Plan, at: SlotId,
+        boundaries: BoundaryPlan,
+    ) -> Verdict | None:
+        del plan
+        slot, word = near.slot(at), near.word_of(at)
+        if slot is None or word is None:
+            return None
+        if slot.nucleus.kind is not NucleusKind.PAUSAL_LONG:
+            return None
+        if boundaries.stopped_on(word):
+            # Stopped on, the alif is said and `WaqfEnding` owns the slot.
+            return None
+        return Verdict(
+            Occurrence(
+                mint(Rule.PAUSAL_ALIF, at), Rule.PAUSAL_ALIF,
+                Participants((at,)),
+            ),
+            (Relength(at, Length.SHORT),),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class TanweenAtWaqf:
     """The tanween noon is silent at a stop; after a fatha it leaves the iwad.
 

--- a/quranic_phonemizer/rules/idgham.py
+++ b/quranic_phonemizer/rules/idgham.py
@@ -14,6 +14,7 @@ from ..model.canon import CanonLetter as L
 from ..model.canon import CanonLetter, NucleusKind, Phase, Rule
 from ..model.performance import Aspect, Consonant, Occurrence, Participants
 from .lam_shamsiyyah import ArticleShape
+from .meem_sakinah import NASAL_LETTERS
 from .tables import Pairs
 
 
@@ -76,7 +77,16 @@ class Idgham:
                 Realize(
                     following.id,
                     Aspect.ONSET,
-                    Consonant(following.letter, geminate=True),
+                    Consonant(
+                        following.letter,
+                        geminate=True,
+                        # A doubled noon or meem is held on its ghunnah
+                        # wherever it stands, and one the idgham doubled is
+                        # no different: the meem of `ٱرْكَب مَّعَنَا` is nasal,
+                        # exactly as `GhunnahMushaddadah` would have made it
+                        # had the rasm written the shadda for itself.
+                        nasal=following.letter in NASAL_LETTERS,
+                    ),
                 ),
                 MergeInto(at, Aspect.ONSET, following.id, Aspect.ONSET),
             ),

--- a/quranic_phonemizer/rules/tafkheem.py
+++ b/quranic_phonemizer/rules/tafkheem.py
@@ -105,6 +105,13 @@ def _raa_is_heavy(near, slot, plan, always_heavy) -> bool:
     ):
         # A raa after a leen yaa follows the yaa and stays light.
         return False
+    if before is not None and before.onset is Onset.WASL:
+        # Only an original kasra lightens. A prosthetic hamza's is aridah --
+        # it exists to be started on and is gone the moment the word is
+        # joined to -- so `ٱرْتَبْتُمْ` is heavy started on and `أَمِ ٱرْتَابُوٓا۟`
+        # is heavy joined, where the kasra heard before the raa is the one
+        # the previous word grew to meet it.
+        return True
     following = near.after(slot.id)
     if (
         following is not None
@@ -119,10 +126,6 @@ def _raa_is_heavy(near, slot, plan, always_heavy) -> bool:
     governing = _governing(near, slot, plan)
     if governing is None:
         return False
-    if _quality(governing) is Quality.I and governing.onset is Onset.WASL:
-        # Only an original kasra lightens. The wasl hamza's is aridah -- it
-        # exists to be started on -- so `ٱرْتَبْتُمْ` is heavy.
-        return True
     return _quality(governing) in (Quality.A, Quality.U)
 
 

--- a/quranic_phonemizer/rules/tafkheem.py
+++ b/quranic_phonemizer/rules/tafkheem.py
@@ -106,9 +106,15 @@ def _raa_is_heavy(near, slot, plan, always_heavy) -> bool:
         # A raa after a leen yaa follows the yaa and stays light.
         return False
     following = near.after(slot.id)
-    if following is not None and following.letter in always_heavy:
+    if (
+        following is not None
+        and not near.crosses_word(slot.id)
+        and following.letter in always_heavy
+    ):
         # A letter of istilaa after a quiescent raa wins over whatever
-        # precedes it: `قِرْطَاسٍ` is heavy despite its kasra.
+        # precedes it: `قِرْطَاسٍ` is heavy despite its kasra. Only inside the
+        # word: `تُصَعِّرْ خَدَّكَ` and `فَٱصْبِرْ صَبْرًا` keep a light raa, because
+        # the letter that would weigh it belongs to the next word.
         return True
     governing = _governing(near, slot, plan)
     if governing is None:

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -13,7 +13,8 @@ from quranic_phonemizer.canon.lexicon import (
     EMPTY,
     MatchMode,
     LexiconError,
-    load_clitic_pronouns,
+    Affixes,
+    load_affixes,
     load_lexicon,
 )
 from quranic_phonemizer.riwayat.hafs.resources import DATA
@@ -25,7 +26,7 @@ SHARED = DATA.parents[1] / "shared"
 def lexicon():
     return load_lexicon(
         DATA / "lexicon.yaml",
-        clitics=load_clitic_pronouns(SHARED / "morphology.yaml"),
+        affixes=load_affixes(SHARED / "morphology.yaml"),
     )
 
 
@@ -37,7 +38,7 @@ def _text(name: str = "lexicon.yaml") -> str:
 def _load(tmp_path: Path, text: str):
     path = tmp_path / "lexicon.yaml"
     path.write_text(text, encoding="utf-8")
-    return load_lexicon(path, clitics=frozenset({"هم"}))
+    return load_lexicon(path, affixes=Affixes(clitics=frozenset({"هم"})))
 
 
 # -- the budget -----------------------------------------------------------
@@ -90,6 +91,13 @@ def test_proclitic_takes_the_key_after_exactly_one_proclitic(lexicon):
     assert not lexicon.is_pausal("وaلaءaنa")
 
 
+def test_a_two_character_prefix_that_is_not_a_proclitic_does_not_match(lexicon):
+    """`جَآءَنَا` ends in the letters and vowels of `أَنَا` behind two characters,
+    and the vocalised notation writes no length, so counting them is not
+    enough to tell it from `وَأَنَا`."""
+    assert not lexicon.is_pausal("جaءaنa")
+
+
 def test_a_lexicon_with_no_sections_answers_no_to_everything():
     assert not EMPTY.is_divine_name("له")
     assert not EMPTY.is_wasl_exempt("ءمن")
@@ -137,7 +145,7 @@ def test_the_clitic_pronouns_are_shared_not_this_riwayah_s(lexicon):
     it would assert something false about every other riwayah."""
     assert (SHARED / "morphology.yaml").exists()
     assert not (DATA / "morphology.yaml").exists()
-    assert lexicon.clitics
+    assert lexicon.affixes.clitics and lexicon.affixes.proclitics
 
 
 def test_a_repeated_clitic_pronoun_is_a_load_error(tmp_path):
@@ -146,4 +154,4 @@ def test_a_repeated_clitic_pronoun_is_a_load_error(tmp_path):
         _text("morphology.yaml").replace('"ه", "هم"', '"ه", "ه"'), encoding="utf-8"
     )
     with pytest.raises(LexiconError, match="twice"):
-        load_clitic_pronouns(path)
+        load_affixes(path)

--- a/tests/test_minimal_pairs.py
+++ b/tests/test_minimal_pairs.py
@@ -49,7 +49,7 @@ PAIRS = [
         "third radical",
     ),
     (
-        ((3, 13, 7), "ʔaltaqaˤta:"),
+        ((3, 13, 7), "ʔiltaqaˤta:"),
         ((2, 197, 26), "ʔattaqQwa:"),
         "a form VIII lam inflected for agreement is still not the article",
     ),


### PR DESCRIPTION
Every regression the audit classified was in a joined reading, which is why
word mode — the only mode the gates measured word by word — was clean. Each
fix is its own commit, and each was checked against the frozen legacy
baselines in all three modes before the next one started.

## Result

Joined-only differences against the frozen baselines, counted the way the
audit counted them (a sound merged across a boundary may be owned by either
word):

| Class | Site | Before | After |
|---|---|---|---|
| R1 tanween's linking kasra before a hamzat al-wasl | 113 words | 113 | 0 |
| R2 the pausal alif ۠ at a join | 73 | 73 | 0 |
| R3 raa after an elided prosthetic hamza read light | 9 | 9 | 0 |
| R4 istilaa in the next word weighing a quiescent raa | 3 | 3 | 0 |
| R5 idgham mutajanisayn taa into dal across a boundary | 2 sites, 4 words | 4 | 0 |
| R6 idgham fired through a sakt | 2 sites, 4 words | 4 | 0 |
| R7 / muqattaat opening running into the next word | 5 | 5 | 0 |
| V9 `mm` where the merged meem should hold its ghunnah | 1 | 1 | 0 |
| مَالِيَهْ read as idgham rather than sakt izhar | 2 | 2 | 0 |

Verse mode goes from 175 differing words to 1, and that one — `يَسْرِ` at
89:4 — is a word-mode row already classified in
`docs/conformance/gate-residues.md`. Continuous goes from 219 to 7.

Nothing was traded: no class grew while another shrank, and word mode moved
only by the five rows the last commit deliberately changes.

## The 7 continuous rows left, and why they stay

All seven sit on a surah seam, and every one is the oracle contradicting
itself rather than us:

- `6:165:21`, `31:34:27`, `36:1:1`, `68:1:1`, `106:1:1` — a tanween noon
  merging into the first word of the next surah. The oracle drops the noon
  and does not geminate or nasalize the host, so it emits an idgham with
  nothing to merge into.
- `94:8:3`, `96:19:5` — the oracle drops the word-final baa outright.

The audit lists these under `n => -`, `b Q => -` and `ll => l`; none is in
the regression set.

## Beyond the audit

- **Muqattaat, general rule.** An opening of named letters ends exactly as it
  would at a pause however the reading continues, so nothing carries from it
  into the word after it. R7 falls out of that rather than being an exception
  bolted onto the noon rules. One direction only: the oracle keeps the ikhfaa
  of `أَحَدًا كٓهيعٓصٓ` at 18:110, so a word standing *before* an opening still
  meets it as an ordinary word.
- **ٱلْتَقَى takes a kasra.** Started on, `3:155:6` now gives `ʔiltaqaˤ:`. The
  oracle is wrong here too, so this is not a regression; it costs five rows
  on the word-mode floor and the reasoning is recorded in the residues file.
  What separates it from `ٱلتَّقْوَىٰ` is written in both scripts — taa is a sun
  letter, so the article before one always spells the shadda of its
  assimilation.
- **No `mm` is emitted.** The alphabet already writes a nasal consonant
  without doubling it, so the inconsistency with the `m̃` of idgham shafawi at
  3:81 was in the rule and not in the notation.
- **مَالِيَهْ is a sakt.** Added as a fifth ledger site, with the citation
  saying it is this package's decision rather than one every source shares.

## Two latent bugs the fixes exposed

Neither was in the audit; both had to be fixed for the rule above it to hold.

- **A word-scoped ledger entry was matched against the single verse a Reading
  is anchored at**, and its word number was read as an index into that verse.
  A reading spanning verses — which is what a joined recitation of a surah is
  — silently dropped every entry outside its first verse: the sakt sites, the
  pausal alifs and the ra'aa nuclei all went missing.
- **The pausal-lexeme matcher accepted any two characters** before an entry,
  so `جَآءَنَا` read as `أَنَا` behind a prefix at seven sites. It showed nothing
  until a rule asked what a pausal long does when joined. Which single letters
  may stand before a word is Arabic and closed, so it joins the clitic
  pronouns in `data/shared/morphology.yaml` rather than becoming a constant.

## Gates

| Gate | Before | After |
|---|---|---|
| round-trip, uthmani | 100.000% | 100.000% |
| cross-script, word | 99.997% | 99.997% |
| cross-script, verse | 100.000% | 100.000% |
| regression, verse | 97.674% | **97.852%** |
| regression, word | 99.928% | 99.921% |
| attestations, uthmani | 178 | **176** |
| attestations, indopak | 239 | **237** |
| L1 | 18 | 18 |

The floors in `.github/workflows/gates.yml` are ratcheted to match, and
`docs/conformance/gate-residues.md` names every row behind each of them.
`pytest`, `tools/comment_lint.py` and `tools/structure_lint.py` are clean.

One existing test asserted the behaviour that is now fixed:
`tests/test_minimal_pairs.py` expected `ʔaltaqaˤta:` for `3:13:7` and now
expects `ʔiltaqaˤta:`. `tests/test_lexicon.py` follows the matcher's new
signature and gains a case for the `جَآءَنَا` false positive.
